### PR TITLE
feat: Add comprehensive unlearning verification suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,128 @@
+# Erasus — Claude Code Guide
+
+## What is this project?
+
+Erasus (**Efficient Representative And Surgical Unlearning Selection**) is a Python framework for machine unlearning across all major foundation model types (LLMs, VLMs, Diffusion, Audio, Video). It surgically removes data, concepts, or behaviors from trained models without full retraining.
+
+## Quick reference
+
+- **Language**: Python 3.9+
+- **Framework**: PyTorch
+- **Package manager**: pip (pyproject.toml)
+- **Entry point**: `erasus` CLI (`erasus/cli/main.py`)
+- **License**: MIT
+
+## Commands
+
+```bash
+# Install (editable, with dev tools)
+pip install -e ".[dev]"
+
+# Run all tests (exclude optional-dep-only tests)
+python3 -m pytest tests/ -v --tb=short --ignore=tests/test_components.py --ignore=tests/unit/test_sprint_b.py --ignore=tests/unit/test_sprint_f.py
+
+# Run a specific test file
+python3 -m pytest tests/unit/test_verification.py -v
+
+# Lint
+ruff check erasus/ tests/
+
+# Format check
+ruff format --check erasus/ tests/
+```
+
+## Architecture
+
+### Core pattern: Registry + Strategy + Selector
+
+Everything is built on a plugin registry:
+
+```
+erasus/core/registry.py     → strategy_registry, selector_registry, model_registry, metric_registry
+erasus/core/base_strategy.py → BaseStrategy (abstract)
+erasus/core/base_selector.py → BaseSelector (abstract)
+erasus/core/base_metric.py   → BaseMetric (abstract)
+erasus/core/base_unlearner.py → BaseUnlearner (abstract)
+```
+
+New strategies/selectors/metrics are registered via `@registry.register("name")` decorator.
+
+### Key directories
+
+```
+erasus/
+├── core/           # Base classes, registry, config, types
+├── unlearners/     # High-level orchestrators (Generic, VLM, LLM, Diffusion, Audio, Video, Federated)
+├── strategies/     # 27 unlearning algorithms (gradient/, parameter/, data/, llm_specific/, diffusion_specific/, vlm_specific/)
+├── selectors/      # 24 coreset selection methods (gradient_based/, geometry_based/, learning_based/, ensemble/)
+├── losses/         # 8 loss functions
+├── metrics/        # 25+ evaluation metrics (forgetting/, utility/, efficiency/, privacy/)
+├── evaluation/     # Adversarial + relearning robustness tests, unified verification suite
+├── models/         # Model wrappers (vlm/, llm/, diffusion/, audio/, video/)
+├── data/           # Dataset loaders, preprocessing, partitioning
+├── privacy/        # DP mechanisms, certificates
+├── certification/  # Formal (epsilon, delta)-removal verification
+├── visualization/  # 16 visualization modules
+├── experiments/    # Experiment tracking, HPO, ablation
+├── cli/            # CLI commands (unlearn, evaluate, benchmark, visualize)
+└── utils/          # Helpers, checkpointing, distributed, profiling
+```
+
+### Data flow
+
+```
+forget_data + retain_data → Selector (picks coreset) → Strategy.unlearn() → Modified Model → Metrics
+```
+
+### Typical usage
+
+```python
+from erasus import ErasusUnlearner
+unlearner = ErasusUnlearner(model=model, strategy="gradient_ascent", selector="influence")
+result = unlearner.fit(forget_data=forget_loader, retain_data=retain_loader, epochs=5)
+metrics = unlearner.evaluate(forget_data=forget_loader, retain_data=retain_loader)
+```
+
+## Code conventions
+
+- **Style**: PEP 8, enforced by ruff (line length 100)
+- **Type hints**: Required on all public functions
+- **Docstrings**: NumPy-style docstrings on public classes and methods
+- **Imports**: Use `from __future__ import annotations` at the top of every module
+- **Base classes**: All strategies extend `BaseStrategy`, all selectors extend `BaseSelector`, all metrics extend `BaseMetric`
+- **Registration**: Use `@registry.register("name")` decorator or register in `__init__.py`
+- **Error handling**: Raise errors for invalid config. Use `warnings.warn()` only with explicit opt-in fallbacks.
+- **No silent fallbacks**: Selectors should raise errors if required data is missing, not silently fall back to random selection (this is a known issue being fixed).
+
+## Testing
+
+- Tests live in `tests/` with `unit/` and `integration/` subdirs
+- Fixtures in `tests/conftest.py` — `TinyClassifier`, `TinyCNN`, `_make_loader()`
+- All tests use synthetic tiny models (input_dim=16, 4 classes) for speed
+- 3 test files require optional deps (`matplotlib`, etc.) and may fail in minimal environments: `test_components.py`, `test_sprint_b.py`, `test_sprint_f.py`
+- Pre-existing failure: `test_imports.py::test_visualization_imports` fails without matplotlib
+
+## Key modules for verification (new)
+
+The `erasus/evaluation/` package implements adversarial unlearning verification:
+
+- **`mia_suite.py`**: 6-attack MIA battery (LOSS, ZLib, Reference, GradNorm, MinK, MinK++)
+- **`memorization.py`**: Extraction Strength, Exact Memorization, Verbatim Memorization metrics
+- **`adversarial.py`**: Cross-prompt leakage, keyword injection, paraphrase robustness tests
+- **`relearning.py`**: Benign fine-tuning, quantization, LoRA relearning, prompt extraction attacks
+- **`verification_suite.py`**: Unified runner that combines all of the above into a single PASS/PARTIAL/FAIL verdict
+
+## Benchmarks
+
+- `benchmarks/tofu/` — TOFU (LLM unlearning, fictitious author QA)
+- `benchmarks/muse/` — MUSE (6-way evaluation)
+- `benchmarks/wmdp/` — WMDP (hazardous knowledge removal)
+- Currently use synthetic data + `BenchmarkModel` for CI. Real model benchmarks planned.
+
+## Important context
+
+- This is a research framework, not a production service
+- The project is pre-v1 (currently 0.1.1, alpha status)
+- Main competitor is OpenUnlearning (CMU, LLM-only). Erasus differentiates via cross-modality support, coreset selection, and verification.
+- See `ROADMAP.md` for the detailed improvement plan
+- See `project_ideas.md` for future extension ideas

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,666 @@
+# Erasus Roadmap: From Alpha to Adopted
+
+> Deep research analysis of the machine unlearning landscape (2024–2026) and a concrete plan to make Erasus the standard framework for the field.
+>
+> Last updated: 2026-03-17
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Where Erasus Stands Today](#2-where-erasus-stands-today)
+3. [The 2024–2025 Research Landscape](#3-the-20242025-research-landscape)
+4. [Competitive Analysis](#4-competitive-analysis)
+5. [The Evaluation Crisis](#5-the-evaluation-crisis)
+6. [Missing SOTA Methods](#6-missing-sota-methods)
+7. [Missing Capabilities](#7-missing-capabilities)
+8. [Architecture & Engineering Improvements](#8-architecture--engineering-improvements)
+9. [Visibility & Community Strategy](#9-visibility--community-strategy)
+10. [Prioritised Action Plan](#10-prioritised-action-plan)
+11. [Positioning & Narrative](#11-positioning--narrative)
+12. [Key References](#12-key-references)
+
+---
+
+## 1. Executive Summary
+
+Erasus is the **only framework attempting unified cross-modality unlearning** (LLMs, VLMs, Diffusion, Audio, Video) with an intelligent coreset selection layer. No competitor covers this breadth. However:
+
+- **The field has moved fast.** Preference-based methods (NPO, SimNPO, AltPO) are now SOTA for LLM unlearning. Erasus has none of them.
+- **Evaluation is in crisis.** ICLR 2025 and CVPR 2025 papers showed that existing unlearning methods are fragile — benchmarks give false confidence, erased concepts revive under fine-tuning, and benign data can "jog" model memory. The framework that solves evaluation wins.
+- **Nobody knows Erasus exists.** Zero public presence, no academic paper, not listed anywhere. The technical work is ~60% there; the community work is 0% there.
+
+The path forward has three pillars:
+
+1. **Visibility** — publish a paper, go public, get listed
+2. **Evaluation rigour** — adversarial stress-tests, relearning attacks, 6-MIA suite
+3. **SOTA methods** — preference-based unlearning, inference-time unlearning, continual unlearning
+
+---
+
+## 2. Where Erasus Stands Today
+
+### What exists (v0.1.1)
+
+| Component | Count | Details |
+|-----------|-------|---------|
+| Unlearning strategies | 27 | Gradient (6), Parameter (5), Data (4), LLM-specific (5), Diffusion-specific (5), VLM-specific (3), Ensemble (1) |
+| Coreset selectors | 24 | Gradient-based (7), Geometry-based (6), Learning-based (4), Ensemble (3), Auto/Random/Full (3) |
+| Evaluation metrics | 25+ | Forgetting (8), Utility (7), Efficiency (4), Privacy (4+) |
+| Loss functions | 8 | Retain-anchor, Contrastive, KL, MMD, Fisher, Adversarial, Triplet, L2 |
+| Model wrappers | 10+ | CLIP, LLaVA, BLIP, Flamingo, LLaMA, GPT, T5, StableDiffusion, DALL-E, Whisper, VideoMAE |
+| Modality unlearners | 7 | Generic, VLM, LLM, Diffusion, Audio, Video, Federated + MultimodalDispatcher |
+| Benchmarks | 3 | TOFU, MUSE, WMDP (synthetic data runners) |
+| Tests | 340+ | 17 test files, unit + integration + end-to-end |
+| Notebooks | 7 | Introduction, coreset analysis, CLIP, GPT-2, Stable Diffusion demos |
+| Examples | 30+ | All modalities covered |
+| CLI | 4 commands | `unlearn`, `evaluate`, `benchmark`, `visualize` |
+| Docs | Sphinx | Quickstart, API reference, user guides, developer guide |
+
+### Genuine differentiators
+
+1. **Cross-modality architecture** — LLM + VLM + Diffusion + Audio + Video under one API. No competitor does this.
+2. **Coreset selection focus** — 24 selectors with quality analysis. Unique in the ecosystem.
+3. **Certification module** — Formal (ε, δ)-removal verification with PAC-style bounds.
+4. **Federated unlearning** — Dedicated `FederatedUnlearner` with FedAvg aggregation. No competitor has this.
+5. **Registry-based plugin system** — Add strategies/selectors/metrics without modifying core code.
+
+### Known gaps (from `project_ideas.md` and code inspection)
+
+- No preference-based unlearning methods (NPO, SimNPO, etc.)
+- Benchmarks use synthetic data and a `BenchmarkModel`, not real models/datasets
+- 7+ selectors silently fall back to random selection on failure
+- No `.pre-commit-config.yaml` despite pre-commit in dev deps
+- No coverage threshold in CI
+- Tests only use synthetic `TinyClassifier` / `BenchmarkModel`
+- No lm-evaluation-harness integration
+- Zero public presence
+
+---
+
+## 3. The 2024–2025 Research Landscape
+
+### Paradigm shifts
+
+The field has undergone three major shifts since Erasus's last update:
+
+#### Shift 1: Preference-based unlearning replaces gradient ascent as SOTA
+
+Gradient ascent on the forget set was the baseline for years. In 2024–2025, preference optimisation methods took over:
+
+| Method | Venue | Innovation |
+|--------|-------|------------|
+| NPO (Negative Preference Optimization) | 2024 | Reference model constrains parameter drift |
+| SimNPO | NeurIPS 2025 | Removes reference model dependency; identifies "reference model bias" in NPO |
+| AltPO (Alternate Preference Optimization) | 2024 | Positive feedback for alternative answers + negative for forget set |
+| FLAT (Loss Adjustment) | ICLR 2025 | Forget-data-only; no retain data or reference model needed |
+| RMU (Representation Misdirection) | 2024 | Manipulates internal representations; strong on WMDP |
+| UNDIAL | 2024 | Self-distillation with logit adjustment for stability |
+
+These methods produce coherent alternative responses instead of the nonsensical output that gradient ascent creates.
+
+#### Shift 2: Fundamental scepticism about approximate unlearning
+
+Multiple 2025 papers challenged whether current methods work at all:
+
+- **"Machine Unlearning Fails to Remove Data Poisoning Attacks"** (ICLR 2025) — existing methods fail across all poison types for both image classifiers and LLMs. Conclusion: "not yet ready for prime time."
+
+- **"Unlearning or Obfuscating?"** (ICLR 2025) — finetuning-based approximate unlearning merely *obfuscates* outputs. A small amount of benign auxiliary data (e.g. public medical articles) can "jog" model memory to output harmful knowledge about bioweapons.
+
+- **"The Illusion of Unlearning"** (CVPR 2025) — ALL concept erasure methods for diffusion models (SalUn, ESD, EDiff, CA, MACE, SPM, SA, Receler, UCE) are unstable. Erased concepts revive under downstream fine-tuning.
+
+- **"LLM Unlearning Benchmarks are Weak Measures of Progress"** (CMU, April 2025) — TOFU and WMDP are fundamentally flawed. Combining forget + retain queries in one prompt resurfaces "unlearned" info. Inserting a forget keyword into a wrong MCQ option causes 28% accuracy drop. Models are fragile, not forgetful.
+
+#### Shift 3: Inference-time and continual unlearning emerge
+
+- **DExperts**: Expert/anti-expert ensemble at decode time. No gradient computation, no model modification. Works on black-box APIs.
+- **delta-UNLEARNING**: Computes logit offsets using small white-box proxy models, applied to black-box LLMs.
+- **FIT (2025)**: Addresses catastrophic forgetting during sequential deletion requests. First serious treatment of continual unlearning.
+- **Meta-Unlearning (ICCV 2025)**: Prevents relearning of erased diffusion concepts via meta-learning.
+
+### NeurIPS 2023 Machine Unlearning Challenge: Lessons
+
+- 1,338 participants, 72 countries, 1,923 submissions
+- Task: unlearn face images from an age predictor
+- Winning pattern: **"erase then repair"** — erase via layer reinitialization/noise injection/gradient modification, then repair via retain-set finetuning with KL-divergence or entropy regularisation
+- Critical finding: simple metrics (accuracy gap) poorly correlate with principled evaluation. Generalization across datasets was poor.
+
+### Regulatory pressure (active)
+
+- **GDPR Article 17** ("Right to Erasure"): Applies but lacks clear guidelines for model-embedded data
+- **EU AI Act** (phased enforcement): Feb 2025 — prohibited practices; Aug 2025 — GPAI obligations; Aug 2027 — high-risk system rules. Unlearning is proposed as a mandated safeguard.
+- No universally accepted verification method for unlearning effectiveness yet — whoever standardises this wins.
+
+---
+
+## 4. Competitive Analysis
+
+### Direct competitors
+
+| Framework | Stars | Scope | Venue | Strengths | Weaknesses |
+|-----------|-------|-------|-------|-----------|------------|
+| **OpenUnlearning** (CMU/Locuslab) | 504 | LLM only | NeurIPS D&B 2025 | 13 methods (incl. NPO, SimNPO, AltPO, RMU), 16 metrics (6 MIA types), 3 benchmarks, 450+ HF checkpoints, Hydra configs | LLM only; no coreset selection; no diffusion/VLM/audio/video |
+| **EasyEdit** (ZJU NLP) | 2,700 | Knowledge editing | ACL 2024 | ROME, MEMIT, 15+ methods, HF Spaces demo, massive community | Not unlearning (editing ≠ forgetting); different paradigm |
+| **OpenUnlearn** (Pawelczyk, CMU) | ~100 | Evaluation | ICLR 2025 | Rigorous poison-based evaluation; 8 algorithms, 3 metrics | Evaluation-only tool |
+| **ZJUNLP Unlearn** | ~50 | LLM | ACL 2025 | ReLearn method, KnowUnDo benchmark, MemFlex | Narrow scope; single research group |
+| **ESD/erasing** (Baulab) | ~500 | Diffusion only | ICCV 2023 | SD, SDXL, FLUX concept erasure | Diffusion only; shown unstable by CVPR 2025 |
+| **FLAT** (UCSC-REAL) | ~50 | LLM | ICLR 2025 | Forget-data-only; no retain data needed | Single method; no framework |
+| **Erasus** | 0 (private) | All modalities | None | Breadth, coreset selection, certification, federated | Zero public presence; missing SOTA methods |
+
+### What OpenUnlearning has that Erasus doesn't
+
+This is the primary competitor and the gap analysis matters:
+
+| Feature | OpenUnlearning | Erasus |
+|---------|---------------|--------|
+| NPO / SimNPO / AltPO | Yes | No |
+| RMU | Yes | No |
+| UNDIAL | Yes | No |
+| WGA (weighted gradient ascent) | Yes | No |
+| 6 MIA attack types (LOSS, ZLib, Reference, GradNorm, MinK, MinK++) | Yes | Only basic MIA + LiRA |
+| Extraction Strength (ES) metric | Yes | No |
+| Exact Memorization (EM) metric | Yes | No |
+| PrivLeak metric | Yes | No |
+| lm-evaluation-harness integration (MMLU, GSM8K, etc.) | Yes | No |
+| Hydra config-driven experiments | Yes | YAML configs exist but not Hydra-level |
+| 450+ public HF checkpoints | Yes | No |
+| Real TOFU/MUSE/WMDP benchmark runs | Yes | Synthetic data only |
+| Published leaderboards with real results | Yes | Leaderboards exist but on synthetic data |
+| System paper at top venue | NeurIPS D&B 2025 | None |
+
+### What Erasus has that nobody else does
+
+| Feature | Erasus | Competitors |
+|---------|--------|-------------|
+| Cross-modality support (LLM + VLM + Diffusion + Audio + Video) | Yes | All are single-modality |
+| 24 coreset selectors with quality analysis | Yes | None focus on this |
+| Certification module with (ε, δ)-removal verification | Yes | None |
+| Federated unlearning | Yes | None |
+| Ensemble unlearning (strategy combination) | Yes | None |
+| 8 loss functions with modular composition | Yes | Hardcoded in others |
+| Visualization suite (16 modules) | Yes | Basic in OpenUnlearning |
+| Privacy module (DP accounting, secure aggregation) | Yes | None |
+
+---
+
+## 5. The Evaluation Crisis
+
+This deserves its own section because **evaluation is both the biggest unsolved problem and Erasus's biggest opportunity**.
+
+### What's wrong with current evaluation
+
+| Problem | Source | Impact |
+|---------|--------|--------|
+| TOFU/WMDP test forget and retain independently | CMU Blog, April 2025 | Combining them in one prompt resurfaces "unlearned" info |
+| Keyword injection breaks WMDP | CMU Blog, April 2025 | Inserting a forget keyword into wrong MCQ option → 28% accuracy drop |
+| Basic MIA (threshold-based) is too weak | OpenUnlearning, NeurIPS D&B 2025 | Passes even when info is still extractable |
+| Concept erasure is unstable | CVPR 2025 | Downstream fine-tuning revives erased concepts |
+| Benign relearning reverses unlearning | ICLR 2025 | Small amounts of public auxiliary data restore harmful knowledge |
+| Quantization breaks unlearning | Emerging 2025 | 4-bit/8-bit quantization can revive erased knowledge |
+| Simple metrics don't correlate with principled evaluation | NeurIPS 2023 Challenge | Accuracy gap ≠ actual forgetting quality |
+
+### What Erasus should build
+
+#### 5.1 Adversarial evaluation suite
+
+A new module — `erasus/evaluation/adversarial/` — with:
+
+- **Cross-prompt leakage test**: Combine forget and retain queries in a single prompt. If unlearned info resurfaces, the method failed.
+- **Keyword injection test**: Insert forget-set keywords into incorrect MCQ options. Measure accuracy degradation.
+- **Paraphrase robustness**: Rephrase forget-set queries. Measure if the model still recalls info under semantic variation.
+- **Multilingual leakage**: If model is multilingual, test if unlearned English knowledge is still accessible in other languages.
+
+#### 5.2 Relearning robustness module
+
+A new module — `erasus/evaluation/relearning/` — with:
+
+- **Benign fine-tuning attack**: Fine-tune the unlearned model on a small amount of benign, publicly available data related to the forget domain. Measure if unlearned knowledge returns.
+- **Quantization attack**: Quantize the unlearned model to 4-bit and 8-bit. Measure knowledge retention via MIA and generation probing.
+- **LoRA relearning**: Attach a LoRA adapter and fine-tune on tangentially related data. Measure concept revival.
+- **Prompt engineering attack**: Use chain-of-thought, role-playing, and jailbreak prompts to extract unlearned info.
+
+#### 5.3 Upgraded MIA suite
+
+Expand from basic MIA to the 6-attack standard:
+
+| MIA Type | Description | Status in Erasus |
+|----------|-------------|------------------|
+| LOSS | Threshold on per-sample loss | Exists (basic MIA) |
+| ZLib | Loss normalised by zlib compression ratio | Missing |
+| Reference | Loss ratio between target and reference model | Missing |
+| GradNorm | Gradient norm of the loss w.r.t. inputs | Missing |
+| MinK | Minimum-k% token probabilities | Missing |
+| MinK++ | Improved MinK with better calibration | Missing |
+| LiRA | Likelihood Ratio Attack | Exists (mia_variants.py) |
+
+#### 5.4 New metrics
+
+| Metric | Description | Status |
+|--------|-------------|--------|
+| Extraction Strength (ES) | How much of the forget data can be extracted via prompting | Missing |
+| Exact Memorization (EM) | Exact string match of forget data in model output | Missing |
+| PrivLeak (from MUSE) | Privacy leakage score | Missing |
+| ROUGE-L (for unlearning) | Overlap between model output and forget data | Exists but not used for unlearning eval |
+| KnowMem (from TOFU) | Knowledge memorisation score | Missing |
+| Verbatim Memorisation | Verbatim reproduction of training data | Missing |
+
+#### 5.5 General capability preservation
+
+Integrate **lm-evaluation-harness** to measure retained model capabilities:
+
+- MMLU (general knowledge)
+- GSM8K (mathematical reasoning)
+- TruthfulQA (truthfulness)
+- HellaSwag (commonsense reasoning)
+- ARC-Challenge (science QA)
+
+This answers the question: "After unlearning, does the model still work?"
+
+---
+
+## 6. Missing SOTA Methods
+
+### Tier 1: Must-add (SOTA on standard benchmarks)
+
+#### 6.1 NPO — Negative Preference Optimization
+
+- **Paper**: Zhang et al., 2024
+- **Key idea**: Treat unlearning as preference optimisation. The forget set provides negative examples. A reference model (the original model before unlearning) constrains how much parameters can drift, preventing catastrophic forgetting.
+- **Why it matters**: First method to frame unlearning as a preference problem rather than a loss maximisation problem. Produces coherent alternative responses instead of nonsensical output.
+- **Where it fits in Erasus**: `erasus/strategies/llm_specific/npo.py`
+
+#### 6.2 SimNPO — Simplified NPO (NeurIPS 2025)
+
+- **Paper**: Fan et al., 2025
+- **Key idea**: Identifies "reference model bias" in NPO — the reference model gives a misleading impression of unlearning effectiveness. Removes reference model dependency entirely. Simpler, faster, and outperforms NPO.
+- **Why it matters**: Current SOTA on multiple benchmarks. The name "Simplicity Prevails" captures the insight that simpler is better.
+- **Where it fits in Erasus**: `erasus/strategies/llm_specific/simnpo.py`
+
+#### 6.3 AltPO — Alternate Preference Optimization
+
+- **Paper**: Choi et al., 2024
+- **Key idea**: Combines negative feedback (forget set) with in-domain positive feedback. The model learns to produce coherent alternative answers to forget-set queries instead of refusing or producing garbage.
+- **Why it matters**: Solves the "utility collapse" problem where aggressive unlearning makes the model useless for related (but non-forget) queries.
+- **Where it fits in Erasus**: `erasus/strategies/llm_specific/altpo.py`
+
+#### 6.4 FLAT — LLM Unlearning via Loss Adjustment (ICLR 2025)
+
+- **Paper**: Li et al., 2025
+- **Key idea**: Eliminates the need for retain data or a reference model. Uses only the forget data to guide unlearning: teaches the model *what not to respond to* and *how to respond* instead. Two components: IDK loss (respond with "I don't know") and Maintain loss (preserve general capabilities via self-distillation).
+- **Why it matters**: Extremely practical. In real scenarios, you often don't have access to the original retain data or a reference model.
+- **Where it fits in Erasus**: `erasus/strategies/llm_specific/flat.py`
+
+#### 6.5 RMU — Representation Misdirection for Unlearning
+
+- **Paper**: Li et al., 2024
+- **Key idea**: Instead of modifying outputs, manipulate internal representations. For forget-set inputs, steer hidden representations toward random vectors. For retain-set inputs, preserve original representations via a contrastive objective.
+- **Why it matters**: Strong performer on WMDP. Operates at a deeper level than output-based methods.
+- **Where it fits in Erasus**: `erasus/strategies/llm_specific/rmu.py`
+
+### Tier 2: Should-add (important for completeness and production scenarios)
+
+#### 6.6 UNDIAL — Self-Distillation Logit Adjustment
+
+- **Paper**: Dong et al., 2024
+- **Key idea**: Uses self-distillation to reduce target-token confidence via logit adjustment. Avoids the instability of gradient ascent by operating in logit space.
+- **Where it fits**: `erasus/strategies/llm_specific/undial.py`
+
+#### 6.7 DExperts — Inference-Time Unlearning
+
+- **Paper**: Liu et al., 2024
+- **Key idea**: No gradient computation. Combine an "expert" model (retain capabilities) and an "anti-expert" model (trained on forget data) at inference time. Recalculate token probabilities at each decoding step: P(token) = P_base(token) + α(P_expert(token) - P_anti-expert(token)).
+- **Why it matters**: Works on black-box models. No model modification needed. Instantly reversible.
+- **Where it fits**: `erasus/strategies/llm_specific/dexperts.py` (or a new `inference_time/` category)
+
+#### 6.8 WGA/FPGA — Token-Weighted Gradient Ascent
+
+- **Paper**: Various, 2024
+- **Key idea**: Instead of uniform gradient ascent on all tokens, weight the gradient by per-token importance. Tokens more associated with the forget concept get higher weight. Fine-grained control over what gets unlearned.
+- **Where it fits**: `erasus/strategies/gradient_methods/weighted_gradient_ascent.py`
+
+#### 6.9 delta-UNLEARNING — Logit Offsets for Black-Box LLMs
+
+- **Paper**: Goel et al., 2024
+- **Key idea**: Train a small white-box proxy model to compute logit offsets. Apply these offsets to the black-box model's outputs at inference time. No access to the target model's parameters needed.
+- **Where it fits**: `erasus/strategies/llm_specific/delta_unlearning.py`
+
+#### 6.10 Meta-Unlearning on Diffusion Models (ICCV 2025)
+
+- **Paper**: Gao et al., 2025
+- **Key idea**: Addresses the relearning vulnerability in diffusion models. Uses meta-learning to make unlearning robust — the model learns to resist concept relearning even when fine-tuned on related data.
+- **Why it matters**: CVPR 2025 showed ALL existing diffusion erasure methods are unstable. This is the first defence.
+- **Where it fits**: `erasus/strategies/diffusion_specific/meta_unlearning.py`
+
+### Tier 3: Nice-to-have (emerging or niche)
+
+| Method | Type | Innovation |
+|--------|------|------------|
+| Sparsity-Aware Unlearning (SAU) | Parameter | Decouples unlearning from sparsification via gradient masking |
+| FIT (continual unlearning) | Framework | Anti-catastrophic forgetting for sequential deletion |
+| MLLMEraser | Multimodal | Test-time activation steering for multimodal LLMs |
+| AdvUnlearn | Diffusion | Adversarial training for robust concept erasure |
+| Adaptive Guided Erasure (ICLR 2025) | Diffusion | Adaptive guidance for concept erasure |
+
+---
+
+## 7. Missing Capabilities
+
+### 7.1 Continual unlearning
+
+**Problem**: Real-world deployment means sequential deletion requests over time (user A requests deletion on Monday, user B on Tuesday, ...). Current methods assume a single forget set. Repeated application causes catastrophic forgetting of general capabilities.
+
+**What to build**:
+- `erasus/unlearners/continual_unlearner.py` — orchestrates sequential unlearning requests
+- Incremental coreset update (don't recompute coresets from scratch each time)
+- Strategy scheduling (adapt learning rate, epochs per deletion request)
+- Catastrophic forgetting detection (monitor general capability metrics between requests)
+- Implements ideas from FIT (2025) — the first serious treatment of this problem
+
+**Why it matters**: First-mover advantage. No framework handles this well.
+
+### 7.2 Inference-time unlearning
+
+**Problem**: Many production models are served via APIs (OpenAI, Anthropic, etc.). You can't modify weights. You need unlearning at inference time.
+
+**What to build**:
+- `erasus/strategies/inference_time/` — new strategy category
+- DExperts-style expert/anti-expert ensembling
+- delta-UNLEARNING logit offset approach
+- Activation steering (manipulation of hidden states during forward pass)
+- Compatible with the existing `BaseStrategy` interface but with a `requires_training = False` flag
+
+**Why it matters**: Bridges the gap between research (full model access) and production (API access only).
+
+### 7.3 Real benchmark integration
+
+**Problem**: Current benchmarks use synthetic data and a `BenchmarkModel` (32→64→64→10 FC network). Published results on synthetic data are not comparable to the field.
+
+**What to build**:
+- Real TOFU integration: `locuslab/TOFU` dataset, Llama-2-7B / Phi-1.5 / GPT-2 models
+- Real WMDP integration: `cais/wmdp` dataset with Zephyr-7B
+- Real MUSE integration: proper 6-way evaluation
+- Maintain synthetic benchmarks for CI (fast, deterministic) but add real-model benchmarks for paper results
+- Automated leaderboard generation with reproducibility hashes
+
+### 7.4 lm-evaluation-harness integration
+
+**Problem**: After unlearning, you need to verify the model still works on general tasks. No way to measure this currently.
+
+**What to build**:
+- `erasus/integrations/lm_eval.py` — wrapper around EleutherAI's lm-evaluation-harness
+- Default evaluation suite: MMLU, GSM8K, TruthfulQA, HellaSwag, ARC-Challenge
+- Pre/post unlearning comparison with delta tracking
+- Integration with `MetricSuite` so it runs automatically during `evaluate()`
+
+### 7.5 HuggingFace Hub integration (checkpoints)
+
+**Problem**: Researchers need pre-trained and unlearned model pairs to reproduce results. OpenUnlearning has 450+ checkpoints.
+
+**What to build**:
+- Push unlearned model checkpoints to HuggingFace Hub for each benchmark × strategy combination
+- Standardised model cards with unlearning metadata (strategy, selector, prune ratio, metrics)
+- One-line loading: `model = erasus.from_pretrained("erasus/tofu-llama2-7b-npo")`
+- Version-controlled with dataset + config hashes for exact reproducibility
+
+---
+
+## 8. Architecture & Engineering Improvements
+
+### 8.1 Silent selector fallbacks
+
+**Problem**: 7+ selectors (`ForgettingEventsSelector`, `ValuationNetworkSelector`, `GlisterSelector`, `DataShapleySelector`, etc.) silently fall back to random selection with just a `warnings.warn()`. This masks real failures.
+
+**Fix**: Default to raising an error. Add an explicit `fallback="random"` parameter that users must opt into. Log fallback events to experiment tracker.
+
+### 8.2 Test coverage
+
+**Problem**: No coverage threshold in CI. All 340+ tests use only synthetic models. Coverage can silently decline.
+
+**Fix**:
+- Add `--cov-fail-under=80` to pytest config
+- Add integration tests with real tiny models (`gpt2`, `openai/clip-vit-base-patch16`) — even one test per modality
+- Add a `tests/real_models/` directory with `@pytest.mark.slow` markers for CI-optional real model tests
+
+### 8.3 Pre-commit hooks
+
+**Problem**: `pre-commit>=3.4` is in dev deps but there's no `.pre-commit-config.yaml`.
+
+**Fix**: Add `.pre-commit-config.yaml` with ruff, mypy, and a minimal test run.
+
+### 8.4 Config system upgrade
+
+**Problem**: YAML configs exist but lack the composition and override capabilities that Hydra provides. OpenUnlearning uses Hydra.
+
+**Options**:
+- **Option A**: Adopt Hydra (full compatibility with OpenUnlearning's config patterns, but heavy dependency)
+- **Option B**: Extend the existing YAML system with composition and CLI overrides (lighter, but less ecosystem compatibility)
+- **Recommendation**: Option A for paper reproducibility; researchers expect Hydra in 2025
+
+### 8.5 Error handling consistency
+
+**Problem**: Mixed patterns — some modules raise, some warn, some silently fall back. No standardised error hierarchy.
+
+**Fix**: Establish a clear policy:
+- **Hard errors**: Invalid configuration, missing required parameters, incompatible model/strategy combinations
+- **Warnings with fallback**: Optional features unavailable (e.g. wandb not installed), selector degradation
+- **Silent**: Debug-level information (loss values, timing)
+
+### 8.6 API stabilisation
+
+**Problem**: `pyproject.toml` says "Development Status :: 3 - Alpha". The API may change.
+
+**Plan**:
+- Audit the public API surface. Document what is stable vs. experimental.
+- Add `@experimental` decorator for unstable APIs that logs a deprecation warning.
+- Bump to 0.2.0 before paper submission with a stable core API.
+
+---
+
+## 9. Visibility & Community Strategy
+
+### 9.1 Academic paper (highest priority)
+
+**Target venues** (in order of impact):
+1. **NeurIPS 2025 Datasets & Benchmarks** — deadline ~June 2025; perfect for a framework paper
+2. **ICML 2026** — if NeurIPS D&B is missed
+3. **MUGen Workshop @ ICML 2025** (July 18, Vancouver) — workshop paper as a stepping stone
+4. **EMNLP 2025 System Demonstrations** — if framing as an NLP tool
+
+**Paper angle**: "Erasus: Unified Cross-Modality Machine Unlearning with Coreset-Driven Forgetting and Adversarial Evaluation"
+- Contribution 1: First framework supporting unlearning across LLMs, VLMs, diffusion, audio, video
+- Contribution 2: Coreset selection for efficient unlearning (24 methods, 90% speedup)
+- Contribution 3: Adversarial evaluation suite exposing failures in standard benchmarks
+- Contribution 4: Comprehensive empirical comparison of 30+ strategies across modalities
+
+### 9.2 Public GitHub launch
+
+**Checklist before going public**:
+- [ ] Clean git history (squash WIP commits)
+- [ ] Ensure no hardcoded paths, tokens, or credentials
+- [ ] Add GitHub topics: `machine-unlearning`, `coreset-selection`, `llm`, `diffusion-models`, `privacy`, `pytorch`
+- [ ] Add social preview image
+- [ ] Create GitHub Releases with changelog
+- [ ] Set up GitHub Discussions for community Q&A
+- [ ] Write a clear CONTRIBUTING.md (already exists — verify it's complete)
+
+### 9.3 Awesome-list submissions
+
+Submit PRs to:
+- [awesome-machine-unlearning](https://github.com/tamlhp/awesome-machine-unlearning) — 1.4k stars
+- [awesome-llm-unlearning](https://github.com/chrisliu298/awesome-llm-unlearning)
+- [Awesome-GenAI-Unlearning](https://github.com/franciscoliu/Awesome-GenAI-Unlearning)
+- [Awesome-Diffusion-Model-Unlearning](https://github.com/hxxdtd/Awesome-Diffusion-Model-Unlearning)
+
+### 9.4 HuggingFace presence
+
+- Push 20+ model checkpoints (unlearned models for TOFU, MUSE, WMDP × top 5 strategies)
+- Create an Erasus organisation on HuggingFace
+- Add a HuggingFace Spaces demo (Gradio-based — already in optional deps)
+- Create dataset cards for any custom evaluation datasets
+
+### 9.5 Blog posts
+
+Write 3–4 blog posts for launch:
+1. **"Introducing Erasus: Unified Machine Unlearning Across Modalities"** — overview, key features, quick start
+2. **"Why Machine Unlearning Evaluation is Broken (And What We're Doing About It)"** — adversarial evaluation suite, relearning attacks
+3. **"Coreset Selection: 90% Faster Unlearning Without Losing Quality"** — the core innovation
+4. **"Unlearning Harry Potter from GPT-2 in 5 Minutes"** — tutorial walkthrough
+
+### 9.6 Community channels
+
+- **Discord server** — preferred over Slack for open-source (better retention, easier invites)
+- **Twitter/X**: Announce the launch, tag relevant researchers (Locuslab, Ken Ziyu Liu, Pawelczyk, etc.)
+- **Reddit**: Post to r/MachineLearning, r/LanguageTechnology
+
+---
+
+## 10. Prioritised Action Plan
+
+### Phase 1: Foundation (Weeks 1–4)
+
+> Goal: Make Erasus publishable and competitive with OpenUnlearning on LLM benchmarks.
+
+| # | Task | Impact | Effort | Details |
+|---|------|--------|--------|---------|
+| 1.1 | Add NPO, SimNPO, AltPO strategies | Critical | Medium | 3 new strategies in `strategies/llm_specific/` |
+| 1.2 | Add FLAT strategy | Critical | Medium | Forget-data-only method; highly practical |
+| 1.3 | Add RMU strategy | Critical | Medium | Representation-based; strong on WMDP |
+| 1.4 | Upgrade MIA suite to 6 attacks | Critical | Medium | ZLib, Reference, GradNorm, MinK, MinK++ |
+| 1.5 | Add ES and EM metrics | High | Low | Extraction Strength, Exact Memorisation |
+| 1.6 | Real TOFU benchmark integration | Critical | High | Real dataset, real models (Phi-1.5 or GPT-2) |
+| 1.7 | Fix silent selector fallbacks | Medium | Low | Default to error, opt-in fallback |
+| 1.8 | Add coverage threshold to CI | Medium | Low | `--cov-fail-under=80` |
+
+### Phase 2: Differentiation (Weeks 5–8)
+
+> Goal: Build features no competitor has. This is the "why Erasus?" story.
+
+| # | Task | Impact | Effort | Details |
+|---|------|--------|--------|---------|
+| 2.1 | Adversarial evaluation suite | High | High | Cross-prompt leakage, keyword injection, paraphrase robustness |
+| 2.2 | Relearning robustness module | High | High | Benign fine-tuning, quantization, LoRA relearning, prompt attacks |
+| 2.3 | lm-evaluation-harness integration | High | Medium | MMLU, GSM8K, TruthfulQA post-unlearning |
+| 2.4 | Real WMDP + MUSE benchmarks | High | Medium | Real datasets, real models |
+| 2.5 | Continual unlearning pipeline | High | High | Sequential deletion without catastrophic forgetting |
+| 2.6 | Inference-time unlearning (DExperts) | Medium | Medium | No-gradient unlearning for production |
+| 2.7 | Meta-unlearning for diffusion | Medium | Medium | Prevents concept relearning (ICCV 2025) |
+
+### Phase 3: Launch (Weeks 9–12)
+
+> Goal: Public launch with academic paper submission.
+
+| # | Task | Impact | Effort | Details |
+|---|------|--------|--------|---------|
+| 3.1 | Write system paper | Critical | High | Target NeurIPS D&B 2025 or ICML 2026 |
+| 3.2 | Public GitHub launch | Critical | Low | Clean history, topics, releases, discussions |
+| 3.3 | HuggingFace checkpoints (20+) | High | Medium | Unlearned models for TOFU/WMDP/MUSE × top strategies |
+| 3.4 | HuggingFace Spaces demo | High | Medium | Gradio-based interactive demo |
+| 3.5 | Awesome-list submissions (4 lists) | High | Low | PRs to 4 curated lists |
+| 3.6 | Blog post series (3–4 posts) | High | Medium | Introduction, evaluation, coreset, tutorial |
+| 3.7 | Discord community setup | Medium | Low | Community channel for users and contributors |
+| 3.8 | API stabilisation + v0.2.0 | Medium | Medium | Audit, document, bump version |
+
+### Phase 4: Growth (Weeks 13+)
+
+> Goal: Sustain momentum and build community.
+
+| # | Task | Impact | Effort | Details |
+|---|------|--------|--------|---------|
+| 4.1 | UNDIAL, WGA, delta-UNLEARNING strategies | Medium | Medium | Complete the method inventory |
+| 4.2 | Hydra config system | Medium | Medium | Reproducible experiment management |
+| 4.3 | Continual unlearning benchmarks | Medium | High | New benchmark for sequential deletion |
+| 4.4 | GNN unlearning support | Medium | High | Graph neural network modality |
+| 4.5 | REST API service | Medium | Medium | FastAPI endpoints for unlearning-as-a-service |
+| 4.6 | RL unlearning support | Low | High | Remove trajectories from RL policies |
+| 4.7 | Competition hosting | High | High | Community benchmark challenge |
+
+---
+
+## 11. Positioning & Narrative
+
+### The wrong narrative
+
+> "Erasus has 27 strategies, 24 selectors, and supports 5 modalities."
+
+This is feature-counting. It doesn't answer "why should I use this?" — especially when 2025 research shows that many strategies don't actually work.
+
+### The right narrative
+
+> "Other frameworks claim to unlearn. Erasus helps you verify it."
+
+The 2025 research reveals a fundamental tension: approximate unlearning may not work. ICLR 2025 showed it fails against data poisoning. CVPR 2025 showed it's unstable for diffusion models. CMU showed benchmarks give false confidence.
+
+Erasus should position itself as the framework that takes this seriously:
+
+1. **Verification-first**: Certification module, adversarial evaluation, relearning robustness testing
+2. **Coreset intelligence**: Not just "apply gradient ascent" but "identify the minimal set that matters, then surgically remove it"
+3. **Cross-modality**: The only framework where you can unlearn from CLIP, GPT-2, Stable Diffusion, and Whisper with the same API
+4. **Honest evaluation**: Report adversarial metrics alongside standard ones. Show where methods fail, not just where they succeed.
+
+### Tagline options
+
+- "Efficient Representative And Surgical Unlearning Selection" (current — accurate but not memorable)
+- "Verify, then forget." (emphasises evaluation)
+- "The machine unlearning framework that doesn't lie to you." (provocative but differentiated)
+- "Unlearn across any modality. Verify it actually worked." (complete positioning)
+
+---
+
+## 12. Key References
+
+### Foundational critiques (must-read)
+
+| Paper | Venue | Key Finding |
+|-------|-------|-------------|
+| Pawelczyk et al., "Machine Unlearning Fails to Remove Data Poisoning Attacks" | ICLR 2025 | Existing methods fail across all poison types |
+| Shumailov et al., "Unlearning or Obfuscating? Jogging the Memory of Unlearned LLMs" | ICLR 2025 | Benign relearning reverses approximate unlearning |
+| George et al., "The Illusion of Unlearning" | CVPR 2025 | All diffusion erasure methods are unstable |
+| Thaker et al., "LLM Unlearning Benchmarks are Weak Measures of Progress" | CMU ML Blog, April 2025 | TOFU/WMDP benchmarks are fundamentally flawed |
+
+### SOTA methods to implement
+
+| Paper | Venue | Method |
+|-------|-------|--------|
+| Zhang et al., "Negative Preference Optimization" | 2024 | NPO |
+| Fan et al., "SimNPO: Simplicity Prevails" | NeurIPS 2025 | SimNPO |
+| Choi et al., "Alternate Preference Optimization" | 2024 | AltPO |
+| Li et al., "LLM Unlearning via Loss Adjustment" | ICLR 2025 | FLAT |
+| Li et al., "Representation Misdirection for Unlearning" | 2024 | RMU |
+| Dong et al., "UNDIAL" | 2024 | UNDIAL |
+| Liu et al., "DExperts" | 2024 | Inference-time unlearning |
+| Gao et al., "Meta-Unlearning on Diffusion Models" | ICCV 2025 | Anti-relearning for diffusion |
+
+### Competing frameworks
+
+| Framework | Repo | Venue |
+|-----------|------|-------|
+| OpenUnlearning | [locuslab/open-unlearning](https://github.com/locuslab/open-unlearning) | NeurIPS D&B 2025 |
+| EasyEdit | [zjunlp/EasyEdit](https://github.com/zjunlp/EasyEdit) | ACL 2024 |
+| OpenUnlearn | [MartinPawelczyk/OpenUnlearn](https://github.com/MartinPawelczyk/OpenUnlearn) | ICLR 2025 |
+| ZJUNLP Unlearn | [zjunlp/unlearn](https://github.com/zjunlp/unlearn) | ACL 2025 |
+| ESD/erasing | [rohitgandikota/erasing](https://github.com/rohitgandikota/erasing) | ICCV 2023 |
+| FLAT | [UCSC-REAL/FLAT](https://github.com/UCSC-REAL/FLAT) | ICLR 2025 |
+
+### Curated paper lists
+
+- [awesome-machine-unlearning](https://github.com/tamlhp/awesome-machine-unlearning)
+- [awesome-llm-unlearning](https://github.com/chrisliu298/awesome-llm-unlearning)
+- [Awesome-GenAI-Unlearning](https://github.com/franciscoliu/Awesome-GenAI-Unlearning)
+- [Awesome-Diffusion-Model-Unlearning](https://github.com/hxxdtd/Awesome-Diffusion-Model-Unlearning)
+
+### Surveys
+
+- "A Survey on Machine Unlearning in LLMs" (2025) — [arXiv:2503.01854](https://arxiv.org/abs/2503.01854)
+- "Machine Unlearning in 2024" — Ken Ziyu Liu, Stanford — [blog](https://ai.stanford.edu/~kzliu/blog/unlearning/)
+- ACM Computing Surveys, "Machine Unlearning" (2025) — [doi:10.1145/3749987](https://doi.org/10.1145/3749987)
+
+### Competitions and workshops
+
+- NeurIPS 2023 Machine Unlearning Challenge — [site](https://unlearning-challenge.github.io)
+- SemEval 2025 Task 4: Unlearning Sensitive Content from LLMs — [site](https://llmunlearningsemeval2025.github.io)
+- MUGen Workshop @ ICML 2025 (July 18, Vancouver) — [site](https://mugenworkshop.github.io)
+
+---
+
+*This document should be updated as the landscape evolves. The machine unlearning field is moving fast — what's SOTA today may be obsolete in 6 months.*

--- a/erasus/evaluation/__init__.py
+++ b/erasus/evaluation/__init__.py
@@ -1,0 +1,44 @@
+"""
+erasus.evaluation — Adversarial evaluation and robustness testing.
+
+This package provides tools that go beyond standard metrics to verify
+whether unlearning *actually* worked under adversarial conditions.
+
+Modules
+-------
+adversarial
+    Cross-prompt leakage, keyword injection, paraphrase robustness.
+relearning
+    Benign fine-tuning attacks, quantization attacks, LoRA relearning.
+verification_suite
+    Unified runner that combines standard metrics, adversarial tests,
+    and robustness checks into a single comprehensive report.
+"""
+
+from erasus.evaluation.adversarial import (
+    AdversarialEvaluator,
+    CrossPromptLeakageTest,
+    KeywordInjectionTest,
+    ParaphraseRobustnessTest,
+)
+from erasus.evaluation.relearning import (
+    RelearningRobustnessEvaluator,
+    BenignFinetuningAttack,
+    QuantizationAttack,
+    LoRARelearningAttack,
+    PromptExtractionAttack,
+)
+from erasus.evaluation.verification_suite import UnlearningVerificationSuite
+
+__all__ = [
+    "AdversarialEvaluator",
+    "CrossPromptLeakageTest",
+    "KeywordInjectionTest",
+    "ParaphraseRobustnessTest",
+    "RelearningRobustnessEvaluator",
+    "BenignFinetuningAttack",
+    "QuantizationAttack",
+    "LoRARelearningAttack",
+    "PromptExtractionAttack",
+    "UnlearningVerificationSuite",
+]

--- a/erasus/evaluation/adversarial.py
+++ b/erasus/evaluation/adversarial.py
@@ -1,0 +1,591 @@
+"""
+erasus.evaluation.adversarial — Adversarial unlearning evaluation.
+
+Implements stress-tests that expose weaknesses in unlearning methods
+missed by standard benchmarks.
+
+Based on findings from:
+- "LLM Unlearning Benchmarks are Weak Measures of Progress" (CMU, 2025)
+- "The Illusion of Unlearning" (CVPR 2025)
+- NeurIPS 2023 Machine Unlearning Challenge findings
+
+Tests
+-----
+CrossPromptLeakageTest
+    Combine forget and retain queries in a single prompt/batch.
+    If unlearned information resurfaces in the joint context, the
+    method has failed — even if it passes independent evaluation.
+
+KeywordInjectionTest
+    Insert forget-set keywords or features into evaluation inputs
+    (e.g., into incorrect MCQ options or unrelated prompts).  Methods
+    that merely suppress surface patterns rather than truly forgetting
+    will show accuracy degradation.
+
+ParaphraseRobustnessTest
+    Apply input perturbations (noise, permutation, augmentation) to
+    forget-set queries.  Robust unlearning should be invariant to
+    input reformulation.
+
+AdversarialEvaluator
+    Runs all adversarial tests and produces a consolidated report.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, TensorDataset
+
+
+# ---------------------------------------------------------------------------
+# Cross-Prompt Leakage
+# ---------------------------------------------------------------------------
+
+class CrossPromptLeakageTest:
+    """
+    Test whether forget-set information leaks when forget and retain
+    samples are presented in the same batch or context.
+
+    Standard benchmarks evaluate forget and retain sets independently.
+    This test combines them: for each forget sample, we pair it with
+    a retain sample and measure whether the model's behavior on the
+    forget sample changes compared to independent evaluation.
+
+    A significant change indicates that context leaks information
+    about the "forgotten" data — the model hasn't truly unlearned.
+
+    Parameters
+    ----------
+    n_pairs : int
+        Number of (forget, retain) pairs to test.  Default: min of
+        available samples.
+    change_threshold : float
+        Minimum relative change in loss to flag as leakage (default 0.1 = 10%).
+    """
+
+    def __init__(self, n_pairs: Optional[int] = None, change_threshold: float = 0.10):
+        self.n_pairs = n_pairs
+        self.change_threshold = change_threshold
+
+    def run(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: DataLoader,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        device = next(model.parameters()).device
+        model.eval()
+
+        # Collect all samples
+        forget_samples = self._collect_samples(forget_data)
+        retain_samples = self._collect_samples(retain_data)
+
+        if len(forget_samples) == 0 or len(retain_samples) == 0:
+            return {"error": "Insufficient data", "passed": False}
+
+        n_pairs = self.n_pairs or min(len(forget_samples), len(retain_samples))
+        n_pairs = min(n_pairs, len(forget_samples), len(retain_samples))
+
+        # Phase 1: Independent evaluation — loss on forget samples alone
+        independent_losses = []
+        for i in range(n_pairs):
+            fx, fy = forget_samples[i]
+            loss = self._compute_loss(model, fx.unsqueeze(0).to(device), fy.unsqueeze(0).to(device))
+            independent_losses.append(loss)
+
+        # Phase 2: Joint evaluation — loss on forget samples when batched with retain
+        joint_losses = []
+        for i in range(n_pairs):
+            fx, fy = forget_samples[i]
+            rx, ry = retain_samples[i]
+            # Create a mini-batch containing both
+            batch_x = torch.stack([fx, rx]).to(device)
+            batch_y = torch.stack([fy, ry]).to(device)
+
+            with torch.no_grad():
+                outputs = model(batch_x)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                # Loss on the forget sample (index 0) within the joint batch
+                loss = F.cross_entropy(outputs[0:1], batch_y[0:1]).item()
+            joint_losses.append(loss)
+
+        independent_arr = np.array(independent_losses)
+        joint_arr = np.array(joint_losses)
+
+        # Compute leakage: relative change in loss
+        # If loss decreases in joint context → model is "remembering" when given context
+        relative_change = (joint_arr - independent_arr) / (np.abs(independent_arr) + 1e-8)
+        leakage_mask = np.abs(relative_change) > self.change_threshold
+        leakage_rate = leakage_mask.mean()
+
+        # Directional analysis
+        loss_decreased = (relative_change < -self.change_threshold).mean()
+        loss_increased = (relative_change > self.change_threshold).mean()
+
+        return {
+            "test": "cross_prompt_leakage",
+            "n_pairs_tested": int(n_pairs),
+            "leakage_rate": float(leakage_rate),
+            "loss_decreased_rate": float(loss_decreased),
+            "loss_increased_rate": float(loss_increased),
+            "mean_relative_change": float(relative_change.mean()),
+            "std_relative_change": float(relative_change.std()),
+            "independent_loss_mean": float(independent_arr.mean()),
+            "joint_loss_mean": float(joint_arr.mean()),
+            "passed": float(leakage_rate) < 0.2,
+            "interpretation": (
+                "Low leakage: model behavior is consistent across contexts (good)"
+                if leakage_rate < 0.2
+                else f"High leakage ({leakage_rate:.1%}): forget-set behavior changes "
+                     f"when presented alongside retain data"
+            ),
+        }
+
+    @staticmethod
+    def _collect_samples(loader: DataLoader) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+        samples = []
+        for batch in loader:
+            if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                continue
+            inputs, targets = batch[0], batch[1]
+            for i in range(inputs.size(0)):
+                samples.append((inputs[i].cpu(), targets[i].cpu()))
+        return samples
+
+    @staticmethod
+    def _compute_loss(
+        model: nn.Module, inputs: torch.Tensor, targets: torch.Tensor,
+    ) -> float:
+        with torch.no_grad():
+            outputs = model(inputs)
+            if hasattr(outputs, "logits"):
+                outputs = outputs.logits
+            return F.cross_entropy(outputs, targets).item()
+
+
+# ---------------------------------------------------------------------------
+# Keyword Injection
+# ---------------------------------------------------------------------------
+
+class KeywordInjectionTest:
+    """
+    Test whether injecting forget-set features into unrelated inputs
+    disrupts the model's predictions.
+
+    Motivation: if a model has truly forgotten a concept, encountering
+    features associated with that concept in new contexts should have
+    no effect.  But if the model merely suppresses a surface pattern,
+    injecting related features will cause measurable degradation.
+
+    Implementation: for classifier models, we blend forget-set features
+    into retain-set inputs at various strengths and measure accuracy
+    change on the retain set.
+
+    Parameters
+    ----------
+    injection_strengths : list[float]
+        Blending weights for feature injection (default [0.05, 0.1, 0.2]).
+    """
+
+    def __init__(
+        self,
+        injection_strengths: Optional[List[float]] = None,
+    ):
+        self.injection_strengths = injection_strengths or [0.05, 0.1, 0.2]
+
+    def run(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: DataLoader,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        device = next(model.parameters()).device
+        model.eval()
+
+        # Compute baseline accuracy on retain set
+        baseline_acc = self._compute_accuracy(model, retain_data, device)
+
+        # Compute mean forget-set features (the "keyword" representation)
+        forget_centroid = self._compute_centroid(forget_data)
+        if forget_centroid is None:
+            return {"error": "Could not compute forget centroid", "passed": False}
+
+        # Inject forget features into retain inputs at various strengths
+        results_by_strength: Dict[str, float] = {}
+        worst_drop = 0.0
+
+        for alpha in self.injection_strengths:
+            injected_acc = self._compute_injected_accuracy(
+                model, retain_data, forget_centroid, alpha, device
+            )
+            drop = baseline_acc - injected_acc
+            worst_drop = max(worst_drop, drop)
+            key = f"alpha_{alpha:.2f}"
+            results_by_strength[f"injection_{key}_accuracy"] = float(injected_acc)
+            results_by_strength[f"injection_{key}_drop"] = float(drop)
+
+        return {
+            "test": "keyword_injection",
+            "baseline_retain_accuracy": float(baseline_acc),
+            **results_by_strength,
+            "worst_accuracy_drop": float(worst_drop),
+            "passed": worst_drop < 0.15,
+            "interpretation": (
+                "Model is robust to forget-feature injection (good)"
+                if worst_drop < 0.15
+                else f"Accuracy drops {worst_drop:.1%} when forget features are "
+                     f"injected — model is fragile, not forgetful"
+            ),
+        }
+
+    @staticmethod
+    def _compute_accuracy(
+        model: nn.Module, loader: DataLoader, device: torch.device,
+    ) -> float:
+        correct = 0
+        total = 0
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                outputs = model(inputs)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                correct += (outputs.argmax(dim=-1) == targets).sum().item()
+                total += targets.size(0)
+        return correct / max(total, 1)
+
+    @staticmethod
+    def _compute_centroid(loader: DataLoader) -> Optional[torch.Tensor]:
+        """Compute the mean feature vector of the dataset."""
+        sum_vec = None
+        count = 0
+        for batch in loader:
+            if not isinstance(batch, (list, tuple)):
+                continue
+            inputs = batch[0]
+            if sum_vec is None:
+                sum_vec = torch.zeros_like(inputs[0], dtype=torch.float64)
+            sum_vec += inputs.sum(dim=0).double()
+            count += inputs.size(0)
+        if sum_vec is None or count == 0:
+            return None
+        return (sum_vec / count).float()
+
+    @staticmethod
+    def _compute_injected_accuracy(
+        model: nn.Module,
+        loader: DataLoader,
+        centroid: torch.Tensor,
+        alpha: float,
+        device: torch.device,
+    ) -> float:
+        """Accuracy on retain data with forget centroid blended in."""
+        correct = 0
+        total = 0
+        centroid_dev = centroid.to(device)
+
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                # Blend: x' = (1 - alpha) * x + alpha * centroid
+                injected = (1 - alpha) * inputs + alpha * centroid_dev.unsqueeze(0)
+                outputs = model(injected)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                correct += (outputs.argmax(dim=-1) == targets).sum().item()
+                total += targets.size(0)
+        return correct / max(total, 1)
+
+
+# ---------------------------------------------------------------------------
+# Paraphrase Robustness
+# ---------------------------------------------------------------------------
+
+class ParaphraseRobustnessTest:
+    """
+    Test whether unlearning is robust to input perturbations.
+
+    If a model has truly unlearned, it should remain uncertain on
+    forget-set samples even when they are perturbed.  If small
+    perturbations restore confident predictions, the unlearning is
+    superficial.
+
+    Perturbation types:
+    - Gaussian noise addition
+    - Feature permutation (shuffle dimensions)
+    - Scaling (multiply by random factors)
+
+    Parameters
+    ----------
+    noise_levels : list[float]
+        Standard deviations for Gaussian noise (default [0.01, 0.05, 0.1]).
+    n_perturbations : int
+        Number of random perturbations per noise level (default 3).
+    """
+
+    def __init__(
+        self,
+        noise_levels: Optional[List[float]] = None,
+        n_perturbations: int = 3,
+    ):
+        self.noise_levels = noise_levels or [0.01, 0.05, 0.1]
+        self.n_perturbations = n_perturbations
+
+    def run(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: Optional[DataLoader] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        device = next(model.parameters()).device
+        model.eval()
+
+        # Baseline: accuracy and confidence on unperturbed forget set
+        baseline_acc, baseline_conf = self._eval(model, forget_data, device)
+
+        # Perturbed evaluations
+        noise_results: Dict[str, float] = {}
+        max_acc_recovery = 0.0
+
+        for sigma in self.noise_levels:
+            accs = []
+            confs = []
+            for _ in range(self.n_perturbations):
+                acc, conf = self._eval_perturbed(
+                    model, forget_data, device, noise_std=sigma,
+                )
+                accs.append(acc)
+                confs.append(conf)
+
+            mean_acc = float(np.mean(accs))
+            mean_conf = float(np.mean(confs))
+            acc_recovery = mean_acc - baseline_acc
+            max_acc_recovery = max(max_acc_recovery, acc_recovery)
+
+            key = f"noise_{sigma:.3f}"
+            noise_results[f"perturbed_{key}_accuracy"] = mean_acc
+            noise_results[f"perturbed_{key}_confidence"] = mean_conf
+            noise_results[f"perturbed_{key}_acc_recovery"] = float(acc_recovery)
+
+        # Permutation test
+        perm_acc, perm_conf = self._eval_permuted(model, forget_data, device)
+        perm_recovery = perm_acc - baseline_acc
+
+        # Scale test
+        scale_acc, scale_conf = self._eval_scaled(model, forget_data, device)
+        scale_recovery = scale_acc - baseline_acc
+
+        max_acc_recovery = max(max_acc_recovery, perm_recovery, scale_recovery)
+
+        return {
+            "test": "paraphrase_robustness",
+            "baseline_forget_accuracy": float(baseline_acc),
+            "baseline_forget_confidence": float(baseline_conf),
+            **noise_results,
+            "permutation_accuracy": float(perm_acc),
+            "permutation_acc_recovery": float(perm_recovery),
+            "scaling_accuracy": float(scale_acc),
+            "scaling_acc_recovery": float(scale_recovery),
+            "max_accuracy_recovery": float(max_acc_recovery),
+            "passed": max_acc_recovery < 0.15,
+            "interpretation": (
+                "Unlearning is robust to input perturbations (good)"
+                if max_acc_recovery < 0.15
+                else f"Perturbations recover {max_acc_recovery:.1%} accuracy — "
+                     f"unlearning is superficial"
+            ),
+        }
+
+    @staticmethod
+    def _eval(
+        model: nn.Module, loader: DataLoader, device: torch.device,
+    ) -> Tuple[float, float]:
+        """Return (accuracy, mean_confidence) on a loader."""
+        correct = 0
+        total = 0
+        confs: list = []
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                outputs = model(inputs)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                probs = torch.softmax(outputs, dim=-1)
+                confs.extend(probs.max(dim=-1).values.cpu().tolist())
+                correct += (outputs.argmax(dim=-1) == targets).sum().item()
+                total += targets.size(0)
+        return correct / max(total, 1), float(np.mean(confs)) if confs else 0.0
+
+    def _eval_perturbed(
+        self, model: nn.Module, loader: DataLoader, device: torch.device,
+        noise_std: float,
+    ) -> Tuple[float, float]:
+        """Evaluate with Gaussian noise added to inputs."""
+        correct = 0
+        total = 0
+        confs: list = []
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                noisy = inputs + torch.randn_like(inputs) * noise_std
+                outputs = model(noisy)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                probs = torch.softmax(outputs, dim=-1)
+                confs.extend(probs.max(dim=-1).values.cpu().tolist())
+                correct += (outputs.argmax(dim=-1) == targets).sum().item()
+                total += targets.size(0)
+        return correct / max(total, 1), float(np.mean(confs)) if confs else 0.0
+
+    @staticmethod
+    def _eval_permuted(
+        model: nn.Module, loader: DataLoader, device: torch.device,
+    ) -> Tuple[float, float]:
+        """Evaluate with feature dimensions permuted."""
+        correct = 0
+        total = 0
+        confs: list = []
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                # Permute the last dimension
+                perm = torch.randperm(inputs.size(-1), device=device)
+                permuted = inputs.index_select(-1, perm)
+                outputs = model(permuted)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                probs = torch.softmax(outputs, dim=-1)
+                confs.extend(probs.max(dim=-1).values.cpu().tolist())
+                correct += (outputs.argmax(dim=-1) == targets).sum().item()
+                total += targets.size(0)
+        return correct / max(total, 1), float(np.mean(confs)) if confs else 0.0
+
+    @staticmethod
+    def _eval_scaled(
+        model: nn.Module, loader: DataLoader, device: torch.device,
+    ) -> Tuple[float, float]:
+        """Evaluate with random per-sample scaling."""
+        correct = 0
+        total = 0
+        confs: list = []
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                # Scale each sample by a random factor in [0.8, 1.2]
+                scale = 0.8 + 0.4 * torch.rand(inputs.size(0), 1, device=device)
+                # Handle multi-dimensional inputs
+                while scale.dim() < inputs.dim():
+                    scale = scale.unsqueeze(-1)
+                scaled = inputs * scale
+                outputs = model(scaled)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                probs = torch.softmax(outputs, dim=-1)
+                confs.extend(probs.max(dim=-1).values.cpu().tolist())
+                correct += (outputs.argmax(dim=-1) == targets).sum().item()
+                total += targets.size(0)
+        return correct / max(total, 1), float(np.mean(confs)) if confs else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Unified Adversarial Evaluator
+# ---------------------------------------------------------------------------
+
+class AdversarialEvaluator:
+    """
+    Runs all adversarial evaluation tests and produces a consolidated report.
+
+    Parameters
+    ----------
+    tests : list[str], optional
+        Subset of tests to run.  Default: all.
+        Valid names: ``cross_prompt``, ``keyword_injection``, ``paraphrase``.
+
+    Example
+    -------
+    >>> evaluator = AdversarialEvaluator()
+    >>> report = evaluator.evaluate(model, forget_loader, retain_loader)
+    >>> print(report["overall"]["passed"])
+    True
+    """
+
+    ALL_TESTS = ("cross_prompt", "keyword_injection", "paraphrase")
+
+    def __init__(
+        self,
+        tests: Optional[List[str]] = None,
+        cross_prompt_kwargs: Optional[Dict[str, Any]] = None,
+        keyword_injection_kwargs: Optional[Dict[str, Any]] = None,
+        paraphrase_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        self.test_names = list(tests or self.ALL_TESTS)
+        self._tests = {
+            "cross_prompt": CrossPromptLeakageTest(**(cross_prompt_kwargs or {})),
+            "keyword_injection": KeywordInjectionTest(**(keyword_injection_kwargs or {})),
+            "paraphrase": ParaphraseRobustnessTest(**(paraphrase_kwargs or {})),
+        }
+
+    def evaluate(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: DataLoader,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Run all selected adversarial tests."""
+        results: Dict[str, Any] = {}
+        n_passed = 0
+        n_total = 0
+
+        for test_name in self.test_names:
+            test = self._tests.get(test_name)
+            if test is None:
+                continue
+
+            try:
+                result = test.run(
+                    model=model,
+                    forget_data=forget_data,
+                    retain_data=retain_data,
+                    **kwargs,
+                )
+                results[test_name] = result
+                if result.get("passed", False):
+                    n_passed += 1
+                n_total += 1
+            except Exception as e:
+                results[test_name] = {"error": str(e), "passed": False}
+                n_total += 1
+
+        results["overall"] = {
+            "tests_passed": n_passed,
+            "tests_total": n_total,
+            "passed": n_passed == n_total,
+            "verdict": "PASS" if n_passed == n_total else (
+                "PARTIAL" if n_passed > 0 else "FAIL"
+            ),
+        }
+
+        return results

--- a/erasus/evaluation/relearning.py
+++ b/erasus/evaluation/relearning.py
@@ -1,0 +1,744 @@
+"""
+erasus.evaluation.relearning — Relearning robustness evaluation.
+
+Tests whether unlearning can be reversed by common post-processing
+operations, exposing methods that merely obfuscate rather than truly
+forget.
+
+Based on:
+- "Unlearning or Obfuscating? Jogging the Memory of Unlearned LLMs
+   via Benign Relearning" (ICLR 2025)
+- "The Illusion of Unlearning" (CVPR 2025)
+
+Attacks
+-------
+BenignFinetuningAttack
+    Fine-tune the unlearned model on a small amount of benign data
+    from the same domain.  If forget-set performance recovers,
+    the model was obfuscating rather than forgetting.
+
+QuantizationAttack
+    Quantize the model to lower precision (8-bit, 4-bit).  Weight
+    quantization can undo subtle parameter changes made during
+    unlearning, reviving erased knowledge.
+
+LoRARelearningAttack
+    Attach a LoRA adapter and fine-tune on tangentially related data.
+    LoRA modifies a small number of parameters; if this is enough to
+    restore forgotten knowledge, unlearning was shallow.
+
+PromptExtractionAttack
+    Use adversarial prompting strategies (prefilling, role-playing,
+    chain-of-thought elicitation) to extract supposedly-forgotten
+    information.  For classifier models, this translates to input
+    manipulation techniques.
+
+RelearningRobustnessEvaluator
+    Runs all attacks and produces a consolidated report.
+"""
+
+from __future__ import annotations
+
+import copy
+import warnings
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, TensorDataset
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _compute_metrics(
+    model: nn.Module, loader: DataLoader, device: torch.device,
+) -> Dict[str, float]:
+    """Compute accuracy and mean loss on a loader."""
+    correct = 0
+    total = 0
+    total_loss = 0.0
+    criterion = nn.CrossEntropyLoss(reduction="sum")
+    model.eval()
+
+    with torch.no_grad():
+        for batch in loader:
+            if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                continue
+            inputs, targets = batch[0].to(device), batch[1].to(device)
+            outputs = model(inputs)
+            if hasattr(outputs, "logits"):
+                outputs = outputs.logits
+            total_loss += criterion(outputs, targets).item()
+            correct += (outputs.argmax(dim=-1) == targets).sum().item()
+            total += targets.size(0)
+
+    return {
+        "accuracy": correct / max(total, 1),
+        "loss": total_loss / max(total, 1),
+        "n_samples": total,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Benign Fine-tuning Attack
+# ---------------------------------------------------------------------------
+
+class BenignFinetuningAttack:
+    """
+    Fine-tune the unlearned model on benign (non-forget) data and
+    check if forget-set performance recovers.
+
+    The intuition: if the model learned a representation that
+    "encodes" the forget data and unlearning merely rotated the
+    output head, then fine-tuning on related data can rotate it back.
+
+    Parameters
+    ----------
+    epochs : int
+        Number of fine-tuning epochs (default 3).
+    lr : float
+        Learning rate for fine-tuning (default 1e-3).
+    finetune_fraction : float
+        Fraction of retain data to use for fine-tuning (default 0.5).
+        The rest is held out for measuring unrelated impact.
+    recovery_threshold : float
+        Maximum allowed accuracy recovery on forget set before the
+        test is considered failed (default 0.15 = 15%).
+    """
+
+    def __init__(
+        self,
+        epochs: int = 3,
+        lr: float = 1e-3,
+        finetune_fraction: float = 0.5,
+        recovery_threshold: float = 0.15,
+    ):
+        self.epochs = epochs
+        self.lr = lr
+        self.finetune_fraction = finetune_fraction
+        self.recovery_threshold = recovery_threshold
+
+    def run(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: DataLoader,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        device = next(model.parameters()).device
+
+        # Measure baseline (pre-attack) metrics
+        pre_forget = _compute_metrics(model, forget_data, device)
+        pre_retain = _compute_metrics(model, retain_data, device)
+
+        # Deep copy the model for the attack
+        attack_model = copy.deepcopy(model).to(device)
+        attack_model.train()
+
+        optimizer = torch.optim.SGD(attack_model.parameters(), lr=self.lr)
+        criterion = nn.CrossEntropyLoss()
+
+        # Fine-tune on a subset of retain data
+        for epoch in range(self.epochs):
+            batch_count = 0
+            max_batches = max(1, int(len(retain_data) * self.finetune_fraction))
+
+            for batch in retain_data:
+                if batch_count >= max_batches:
+                    break
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                optimizer.zero_grad()
+                outputs = attack_model(inputs)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                loss = criterion(outputs, targets)
+                loss.backward()
+                optimizer.step()
+                batch_count += 1
+
+        # Measure post-attack metrics
+        post_forget = _compute_metrics(attack_model, forget_data, device)
+        post_retain = _compute_metrics(attack_model, retain_data, device)
+
+        # Compute recovery
+        acc_recovery = post_forget["accuracy"] - pre_forget["accuracy"]
+        loss_recovery = pre_forget["loss"] - post_forget["loss"]
+
+        return {
+            "test": "benign_finetuning",
+            "epochs": self.epochs,
+            "lr": self.lr,
+            "pre_forget_accuracy": float(pre_forget["accuracy"]),
+            "post_forget_accuracy": float(post_forget["accuracy"]),
+            "forget_accuracy_recovery": float(acc_recovery),
+            "pre_forget_loss": float(pre_forget["loss"]),
+            "post_forget_loss": float(post_forget["loss"]),
+            "forget_loss_recovery": float(loss_recovery),
+            "pre_retain_accuracy": float(pre_retain["accuracy"]),
+            "post_retain_accuracy": float(post_retain["accuracy"]),
+            "retain_accuracy_change": float(post_retain["accuracy"] - pre_retain["accuracy"]),
+            "passed": acc_recovery < self.recovery_threshold,
+            "interpretation": (
+                f"Benign fine-tuning recovered only {acc_recovery:.1%} accuracy (robust)"
+                if acc_recovery < self.recovery_threshold
+                else f"Benign fine-tuning recovered {acc_recovery:.1%} accuracy — "
+                     f"model was obfuscating, not truly forgetting"
+            ),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Quantization Attack
+# ---------------------------------------------------------------------------
+
+class QuantizationAttack:
+    """
+    Quantize model weights and check if forget-set performance recovers.
+
+    Unlearning methods that make small, precise parameter changes can
+    be undone by the rounding effects of weight quantization.  This is
+    a real threat in production where models are routinely quantized
+    for inference.
+
+    Parameters
+    ----------
+    bit_widths : list[int]
+        Bit widths to test (default [8, 4]).
+    recovery_threshold : float
+        Maximum allowed accuracy recovery (default 0.10 = 10%).
+    """
+
+    def __init__(
+        self,
+        bit_widths: Optional[List[int]] = None,
+        recovery_threshold: float = 0.10,
+    ):
+        self.bit_widths = bit_widths or [8, 4]
+        self.recovery_threshold = recovery_threshold
+
+    def run(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: Optional[DataLoader] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        device = next(model.parameters()).device
+
+        # Baseline
+        pre_forget = _compute_metrics(model, forget_data, device)
+        pre_retain = _compute_metrics(model, retain_data, device) if retain_data else {}
+
+        results_by_bits: Dict[str, float] = {}
+        worst_recovery = 0.0
+
+        for bits in self.bit_widths:
+            quantized = self._quantize_model(model, bits)
+            quantized = quantized.to(device)
+
+            post_forget = _compute_metrics(quantized, forget_data, device)
+            acc_recovery = post_forget["accuracy"] - pre_forget["accuracy"]
+            worst_recovery = max(worst_recovery, acc_recovery)
+
+            key = f"{bits}bit"
+            results_by_bits[f"quant_{key}_forget_accuracy"] = float(post_forget["accuracy"])
+            results_by_bits[f"quant_{key}_forget_recovery"] = float(acc_recovery)
+
+            if retain_data:
+                post_retain = _compute_metrics(quantized, retain_data, device)
+                results_by_bits[f"quant_{key}_retain_accuracy"] = float(post_retain["accuracy"])
+
+            del quantized
+
+        return {
+            "test": "quantization",
+            "bit_widths_tested": self.bit_widths,
+            "pre_forget_accuracy": float(pre_forget["accuracy"]),
+            **results_by_bits,
+            "worst_recovery": float(worst_recovery),
+            "passed": worst_recovery < self.recovery_threshold,
+            "interpretation": (
+                f"Quantization recovered at most {worst_recovery:.1%} accuracy (robust)"
+                if worst_recovery < self.recovery_threshold
+                else f"Quantization recovered {worst_recovery:.1%} accuracy — "
+                     f"unlearning changes are too fine-grained to survive quantization"
+            ),
+        }
+
+    @staticmethod
+    def _quantize_model(model: nn.Module, bits: int) -> nn.Module:
+        """
+        Simulate uniform symmetric quantization of model weights.
+
+        This is a simple simulation — not hardware-native quantization —
+        but captures the core effect of rounding weights to lower precision.
+        """
+        quantized = copy.deepcopy(model)
+
+        n_levels = 2 ** (bits - 1)  # Symmetric quantization
+
+        with torch.no_grad():
+            for param in quantized.parameters():
+                if param.numel() == 0:
+                    continue
+                # Per-tensor symmetric quantization
+                abs_max = param.abs().max().clamp(min=1e-8)
+                scale = abs_max / n_levels
+
+                # Quantize and dequantize
+                quantized_vals = torch.round(param / scale).clamp(-n_levels, n_levels - 1)
+                param.copy_(quantized_vals * scale)
+
+        return quantized
+
+
+# ---------------------------------------------------------------------------
+# LoRA Relearning Attack
+# ---------------------------------------------------------------------------
+
+class LoRARelearningAttack:
+    """
+    Attach a low-rank adapter and fine-tune on retain data to test
+    if forgotten knowledge can be recovered through LoRA.
+
+    LoRA modifies only a small number of parameters (rank r).  If
+    this is sufficient to restore forget-set performance, the
+    unlearning was not deep enough.
+
+    Parameters
+    ----------
+    rank : int
+        LoRA rank (default 4).
+    epochs : int
+        Fine-tuning epochs (default 3).
+    lr : float
+        Learning rate (default 1e-3).
+    recovery_threshold : float
+        Maximum allowed accuracy recovery (default 0.15).
+    """
+
+    def __init__(
+        self,
+        rank: int = 4,
+        epochs: int = 3,
+        lr: float = 1e-3,
+        recovery_threshold: float = 0.15,
+    ):
+        self.rank = rank
+        self.epochs = epochs
+        self.lr = lr
+        self.recovery_threshold = recovery_threshold
+
+    def run(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: DataLoader,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        device = next(model.parameters()).device
+
+        # Baseline
+        pre_forget = _compute_metrics(model, forget_data, device)
+
+        # Create LoRA-augmented model
+        lora_model = _LoRAWrapper(model, rank=self.rank).to(device)
+        lora_model.train()
+
+        # Only train LoRA parameters
+        lora_params = [p for n, p in lora_model.named_parameters() if "lora_" in n]
+        if not lora_params:
+            return {
+                "test": "lora_relearning",
+                "error": "No LoRA parameters found (model may not have linear layers)",
+                "passed": True,
+            }
+
+        optimizer = torch.optim.Adam(lora_params, lr=self.lr)
+        criterion = nn.CrossEntropyLoss()
+
+        # Fine-tune LoRA on retain data
+        for epoch in range(self.epochs):
+            for batch in retain_data:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                optimizer.zero_grad()
+                outputs = lora_model(inputs)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                loss = criterion(outputs, targets)
+                loss.backward()
+                optimizer.step()
+
+        # Measure post-LoRA metrics
+        post_forget = _compute_metrics(lora_model, forget_data, device)
+        acc_recovery = post_forget["accuracy"] - pre_forget["accuracy"]
+
+        # Count trainable parameters
+        n_lora_params = sum(p.numel() for p in lora_params)
+        n_total_params = sum(p.numel() for p in model.parameters())
+
+        return {
+            "test": "lora_relearning",
+            "rank": self.rank,
+            "epochs": self.epochs,
+            "lora_params": int(n_lora_params),
+            "total_params": int(n_total_params),
+            "lora_param_ratio": float(n_lora_params / max(n_total_params, 1)),
+            "pre_forget_accuracy": float(pre_forget["accuracy"]),
+            "post_forget_accuracy": float(post_forget["accuracy"]),
+            "forget_accuracy_recovery": float(acc_recovery),
+            "passed": acc_recovery < self.recovery_threshold,
+            "interpretation": (
+                f"LoRA (rank {self.rank}) recovered only {acc_recovery:.1%} accuracy (robust)"
+                if acc_recovery < self.recovery_threshold
+                else f"LoRA (rank {self.rank}, {n_lora_params} params) recovered "
+                     f"{acc_recovery:.1%} accuracy — unlearning is shallow"
+            ),
+        }
+
+
+class _LoRAWrapper(nn.Module):
+    """
+    Wraps a model with LoRA adapters on all Linear layers.
+
+    This is a lightweight LoRA implementation for evaluation purposes
+    (does not depend on the ``peft`` library).
+    """
+
+    def __init__(self, base_model: nn.Module, rank: int = 4, alpha: float = 1.0):
+        super().__init__()
+        self.base_model = copy.deepcopy(base_model)
+        self.rank = rank
+        self.alpha = alpha
+        self._adapters: nn.ModuleDict = nn.ModuleDict()
+
+        # Freeze base model
+        for param in self.base_model.parameters():
+            param.requires_grad = False
+
+        # Add LoRA adapters to Linear layers
+        self._inject_lora(self.base_model, prefix="")
+
+    def _inject_lora(self, module: nn.Module, prefix: str) -> None:
+        for name, child in module.named_children():
+            full_name = f"{prefix}.{name}" if prefix else name
+            if isinstance(child, nn.Linear):
+                in_f, out_f = child.in_features, child.out_features
+                r = min(self.rank, in_f, out_f)
+                # Store adapter using a safe key name
+                safe_key = full_name.replace(".", "_")
+                self._adapters[f"lora_A_{safe_key}"] = nn.Linear(in_f, r, bias=False)
+                self._adapters[f"lora_B_{safe_key}"] = nn.Linear(r, out_f, bias=False)
+                # Initialize B to zero so LoRA starts as identity
+                nn.init.zeros_(self._adapters[f"lora_B_{safe_key}"].weight)
+                nn.init.normal_(self._adapters[f"lora_A_{safe_key}"].weight, std=0.02)
+
+                # Replace the forward of this Linear
+                original_forward = child.forward
+
+                def make_hook(a_key: str, b_key: str, orig_fn):
+                    def new_forward(x):
+                        base_out = orig_fn(x)
+                        lora_out = self._adapters[b_key](self._adapters[a_key](x))
+                        return base_out + self.alpha * lora_out
+                    return new_forward
+
+                child.forward = make_hook(f"lora_A_{safe_key}", f"lora_B_{safe_key}", original_forward)
+            else:
+                self._inject_lora(child, full_name)
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        return self.base_model(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Prompt Extraction Attack
+# ---------------------------------------------------------------------------
+
+class PromptExtractionAttack:
+    """
+    Attempt to extract forgotten information via input manipulation.
+
+    For classifier models, this uses:
+    1. Gradient-guided adversarial perturbation toward the correct class
+    2. Input interpolation between forget and retain samples
+    3. Feature amplification (scaling input dimensions that the model
+       attends to most)
+
+    For generative models (if `generate` method exists), this would
+    use prompt engineering — but that is left for future implementation.
+
+    Parameters
+    ----------
+    n_pgd_steps : int
+        PGD steps for adversarial perturbation (default 10).
+    epsilon : float
+        Maximum perturbation L∞ norm (default 0.1).
+    recovery_threshold : float
+        Maximum allowed accuracy recovery (default 0.10).
+    """
+
+    def __init__(
+        self,
+        n_pgd_steps: int = 10,
+        epsilon: float = 0.1,
+        recovery_threshold: float = 0.10,
+    ):
+        self.n_pgd_steps = n_pgd_steps
+        self.epsilon = epsilon
+        self.recovery_threshold = recovery_threshold
+
+    def run(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: Optional[DataLoader] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        device = next(model.parameters()).device
+
+        # Baseline accuracy on forget set
+        pre_metrics = _compute_metrics(model, forget_data, device)
+
+        # Attack 1: PGD adversarial perturbation toward correct class
+        pgd_acc = self._pgd_attack(model, forget_data, device)
+
+        # Attack 2: Input interpolation with retain samples
+        interp_acc = 0.0
+        if retain_data is not None:
+            interp_acc = self._interpolation_attack(model, forget_data, retain_data, device)
+
+        # Attack 3: Feature amplification
+        amp_acc = self._amplification_attack(model, forget_data, device)
+
+        worst_recovery = max(
+            pgd_acc - pre_metrics["accuracy"],
+            interp_acc - pre_metrics["accuracy"],
+            amp_acc - pre_metrics["accuracy"],
+        )
+
+        return {
+            "test": "prompt_extraction",
+            "pre_forget_accuracy": float(pre_metrics["accuracy"]),
+            "pgd_accuracy": float(pgd_acc),
+            "pgd_recovery": float(pgd_acc - pre_metrics["accuracy"]),
+            "interpolation_accuracy": float(interp_acc),
+            "interpolation_recovery": float(interp_acc - pre_metrics["accuracy"]),
+            "amplification_accuracy": float(amp_acc),
+            "amplification_recovery": float(amp_acc - pre_metrics["accuracy"]),
+            "worst_recovery": float(worst_recovery),
+            "passed": worst_recovery < self.recovery_threshold,
+            "interpretation": (
+                f"Prompt extraction recovered at most {worst_recovery:.1%} (robust)"
+                if worst_recovery < self.recovery_threshold
+                else f"Prompt extraction recovered {worst_recovery:.1%} accuracy — "
+                     f"forgotten information is still accessible via input manipulation"
+            ),
+        }
+
+    def _pgd_attack(
+        self, model: nn.Module, loader: DataLoader, device: torch.device,
+    ) -> float:
+        """PGD attack to maximize P(correct class) on forget set."""
+        model.eval()
+        correct = 0
+        total = 0
+        step_size = self.epsilon / max(self.n_pgd_steps, 1) * 2
+
+        for batch in loader:
+            if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                continue
+            inputs, targets = batch[0].to(device), batch[1].to(device)
+            adv_inputs = inputs.clone().detach().requires_grad_(True)
+
+            for step in range(self.n_pgd_steps):
+                outputs = model(adv_inputs)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                # Maximize probability of the true class (minimize negative log-prob)
+                loss = F.cross_entropy(outputs, targets)
+                loss.backward()
+
+                with torch.no_grad():
+                    # Gradient descent on the loss = moving toward correct class
+                    grad = adv_inputs.grad.sign()
+                    adv_inputs = adv_inputs - step_size * grad
+                    # Project back to epsilon ball
+                    delta = (adv_inputs - inputs).clamp(-self.epsilon, self.epsilon)
+                    adv_inputs = (inputs + delta).detach().requires_grad_(True)
+
+            with torch.no_grad():
+                outputs = model(adv_inputs)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                correct += (outputs.argmax(dim=-1) == targets).sum().item()
+                total += targets.size(0)
+
+        return correct / max(total, 1)
+
+    @staticmethod
+    def _interpolation_attack(
+        model: nn.Module,
+        forget_loader: DataLoader,
+        retain_loader: DataLoader,
+        device: torch.device,
+        alpha: float = 0.3,
+    ) -> float:
+        """Interpolate forget inputs toward retain inputs."""
+        model.eval()
+        correct = 0
+        total = 0
+
+        forget_iter = iter(forget_loader)
+        retain_iter = iter(retain_loader)
+
+        while True:
+            try:
+                f_batch = next(forget_iter)
+                r_batch = next(retain_iter)
+            except StopIteration:
+                break
+
+            if not isinstance(f_batch, (list, tuple)) or len(f_batch) < 2:
+                continue
+            if not isinstance(r_batch, (list, tuple)) or len(r_batch) < 2:
+                continue
+
+            f_inputs, f_targets = f_batch[0].to(device), f_batch[1].to(device)
+            r_inputs = r_batch[0].to(device)
+
+            # Match batch sizes
+            min_size = min(f_inputs.size(0), r_inputs.size(0))
+            mixed = (1 - alpha) * f_inputs[:min_size] + alpha * r_inputs[:min_size]
+
+            with torch.no_grad():
+                outputs = model(mixed)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                correct += (outputs.argmax(dim=-1) == f_targets[:min_size]).sum().item()
+                total += min_size
+
+        return correct / max(total, 1)
+
+    @staticmethod
+    def _amplification_attack(
+        model: nn.Module, loader: DataLoader, device: torch.device,
+        factor: float = 2.0,
+    ) -> float:
+        """Amplify input features to boost signal."""
+        model.eval()
+        correct = 0
+        total = 0
+
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                amplified = inputs * factor
+                outputs = model(amplified)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                correct += (outputs.argmax(dim=-1) == targets).sum().item()
+                total += targets.size(0)
+
+        return correct / max(total, 1)
+
+
+# ---------------------------------------------------------------------------
+# Unified Relearning Robustness Evaluator
+# ---------------------------------------------------------------------------
+
+class RelearningRobustnessEvaluator:
+    """
+    Runs all relearning robustness attacks and produces a consolidated report.
+
+    Parameters
+    ----------
+    attacks : list[str], optional
+        Subset of attacks to run.  Default: all.
+        Valid names: ``benign_finetuning``, ``quantization``,
+        ``lora_relearning``, ``prompt_extraction``.
+
+    Example
+    -------
+    >>> evaluator = RelearningRobustnessEvaluator()
+    >>> report = evaluator.evaluate(model, forget_loader, retain_loader)
+    >>> print(report["overall"]["verdict"])
+    PASS
+    """
+
+    ALL_ATTACKS = (
+        "benign_finetuning",
+        "quantization",
+        "lora_relearning",
+        "prompt_extraction",
+    )
+
+    def __init__(
+        self,
+        attacks: Optional[List[str]] = None,
+        benign_finetuning_kwargs: Optional[Dict[str, Any]] = None,
+        quantization_kwargs: Optional[Dict[str, Any]] = None,
+        lora_relearning_kwargs: Optional[Dict[str, Any]] = None,
+        prompt_extraction_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        self.attack_names = list(attacks or self.ALL_ATTACKS)
+        self._attacks = {
+            "benign_finetuning": BenignFinetuningAttack(**(benign_finetuning_kwargs or {})),
+            "quantization": QuantizationAttack(**(quantization_kwargs or {})),
+            "lora_relearning": LoRARelearningAttack(**(lora_relearning_kwargs or {})),
+            "prompt_extraction": PromptExtractionAttack(**(prompt_extraction_kwargs or {})),
+        }
+
+    def evaluate(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: DataLoader,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Run all selected relearning robustness attacks."""
+        results: Dict[str, Any] = {}
+        n_passed = 0
+        n_total = 0
+
+        for attack_name in self.attack_names:
+            attack = self._attacks.get(attack_name)
+            if attack is None:
+                continue
+
+            try:
+                result = attack.run(
+                    model=model,
+                    forget_data=forget_data,
+                    retain_data=retain_data,
+                    **kwargs,
+                )
+                results[attack_name] = result
+                if result.get("passed", False):
+                    n_passed += 1
+                n_total += 1
+            except Exception as e:
+                results[attack_name] = {"error": str(e), "passed": False}
+                n_total += 1
+
+        results["overall"] = {
+            "attacks_passed": n_passed,
+            "attacks_total": n_total,
+            "passed": n_passed == n_total,
+            "verdict": "PASS" if n_passed == n_total else (
+                "PARTIAL" if n_passed > 0 else "FAIL"
+            ),
+        }
+
+        return results

--- a/erasus/evaluation/verification_suite.py
+++ b/erasus/evaluation/verification_suite.py
@@ -1,0 +1,250 @@
+"""
+erasus.evaluation.verification_suite — Unified unlearning verification.
+
+Combines standard metrics, adversarial tests, relearning robustness
+checks, and the full MIA suite into a single comprehensive report
+that answers: "Did unlearning actually work?"
+
+This is the top-level entry point for rigorous unlearning evaluation.
+
+Example
+-------
+>>> from erasus.evaluation import UnlearningVerificationSuite
+>>> suite = UnlearningVerificationSuite()
+>>> report = suite.verify(model, forget_loader, retain_loader)
+>>> print(report["verdict"])
+PASS
+>>> print(report["confidence"])
+0.85
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from erasus.evaluation.adversarial import AdversarialEvaluator
+from erasus.evaluation.relearning import RelearningRobustnessEvaluator
+from erasus.metrics.forgetting.mia_suite import MIASuite
+from erasus.metrics.forgetting.memorization import (
+    ExactMemorizationMetric,
+    ExtractionStrengthMetric,
+    VerbatimMemorizationMetric,
+)
+
+
+class UnlearningVerificationSuite:
+    """
+    Comprehensive unlearning verification.
+
+    Runs four categories of evaluation:
+
+    1. **MIA Suite** — 6-attack membership inference battery
+    2. **Memorization Metrics** — extraction strength, exact memorization,
+       verbatim memorization
+    3. **Adversarial Tests** — cross-prompt leakage, keyword injection,
+       paraphrase robustness
+    4. **Relearning Robustness** — benign fine-tuning, quantization,
+       LoRA relearning, prompt extraction attacks
+
+    Produces a single verdict (PASS/PARTIAL/FAIL) with a confidence
+    score based on how many tests pass and the severity of failures.
+
+    Parameters
+    ----------
+    categories : list[str], optional
+        Which categories to run.  Default: all.
+        Valid: ``mia``, ``memorization``, ``adversarial``, ``relearning``.
+    reference_model : nn.Module, optional
+        Reference model (pre-unlearning) for the Reference MIA attack.
+    strict : bool
+        If True, requires ALL tests to pass for a PASS verdict.
+        If False (default), allows partial passes with reduced confidence.
+
+    Example
+    -------
+    >>> suite = UnlearningVerificationSuite(categories=["mia", "adversarial"])
+    >>> report = suite.verify(model, forget_loader, retain_loader)
+    """
+
+    ALL_CATEGORIES = ("mia", "memorization", "adversarial", "relearning")
+
+    def __init__(
+        self,
+        categories: Optional[List[str]] = None,
+        reference_model: Optional[nn.Module] = None,
+        strict: bool = False,
+        # Pass-through kwargs for sub-evaluators
+        mia_kwargs: Optional[Dict[str, Any]] = None,
+        adversarial_kwargs: Optional[Dict[str, Any]] = None,
+        relearning_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        self.categories = list(categories or self.ALL_CATEGORIES)
+        self.reference_model = reference_model
+        self.strict = strict
+
+        # Initialize sub-evaluators
+        self._mia = MIASuite(reference_model=reference_model, **(mia_kwargs or {}))
+        self._extraction = ExtractionStrengthMetric()
+        self._exact_mem = ExactMemorizationMetric()
+        self._verbatim = VerbatimMemorizationMetric()
+        self._adversarial = AdversarialEvaluator(**(adversarial_kwargs or {}))
+        self._relearning = RelearningRobustnessEvaluator(**(relearning_kwargs or {}))
+
+    def verify(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: DataLoader,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Run the full verification suite.
+
+        Returns
+        -------
+        dict
+            Nested results for each category, plus top-level:
+            - ``verdict``: PASS / PARTIAL / FAIL
+            - ``confidence``: float in [0, 1]
+            - ``summary``: human-readable summary
+            - ``_meta``: timing and configuration info
+        """
+        t0 = time.time()
+        results: Dict[str, Any] = {}
+        scores: List[float] = []  # Per-category scores [0, 1]
+
+        # --- Category 1: MIA Suite ---
+        if "mia" in self.categories:
+            try:
+                mia_results = self._mia.compute(
+                    model=model,
+                    forget_data=forget_data,
+                    retain_data=retain_data,
+                    **kwargs,
+                )
+                results["mia"] = mia_results
+                # Score: how close mean AUC is to 0.5 (ideal)
+                mean_auc = mia_results.get("mia_suite_mean_auc", 0.5)
+                mia_score = 1.0 - 2 * abs(mean_auc - 0.5)
+                scores.append(max(0.0, mia_score))
+            except Exception as e:
+                results["mia"] = {"error": str(e)}
+                scores.append(0.0)
+
+        # --- Category 2: Memorization Metrics ---
+        if "memorization" in self.categories:
+            mem_results: Dict[str, Any] = {}
+            try:
+                es = self._extraction.compute(model, forget_data, retain_data)
+                mem_results["extraction_strength"] = es
+            except Exception as e:
+                mem_results["extraction_strength"] = {"error": str(e)}
+
+            try:
+                em = self._exact_mem.compute(model, forget_data, retain_data)
+                mem_results["exact_memorization"] = em
+            except Exception as e:
+                mem_results["exact_memorization"] = {"error": str(e)}
+
+            try:
+                vm = self._verbatim.compute(model, forget_data, retain_data)
+                mem_results["verbatim_memorization"] = vm
+            except Exception as e:
+                mem_results["verbatim_memorization"] = {"error": str(e)}
+
+            results["memorization"] = mem_results
+
+            # Score: based on extraction resistance and low memorization
+            es_resist = mem_results.get("extraction_strength", {}).get("extraction_resistance", 0.5)
+            em_gap = mem_results.get("exact_memorization", {}).get("exact_memorization_gap", 0.0)
+            # Higher gap (retain > forget) = better
+            mem_score = min(1.0, max(0.0, es_resist * 0.7 + min(em_gap + 0.5, 1.0) * 0.3))
+            scores.append(mem_score)
+
+        # --- Category 3: Adversarial Tests ---
+        if "adversarial" in self.categories:
+            try:
+                adv_results = self._adversarial.evaluate(
+                    model=model,
+                    forget_data=forget_data,
+                    retain_data=retain_data,
+                    **kwargs,
+                )
+                results["adversarial"] = adv_results
+                overall = adv_results.get("overall", {})
+                n_passed = overall.get("tests_passed", 0)
+                n_total = overall.get("tests_total", 1)
+                scores.append(n_passed / max(n_total, 1))
+            except Exception as e:
+                results["adversarial"] = {"error": str(e)}
+                scores.append(0.0)
+
+        # --- Category 4: Relearning Robustness ---
+        if "relearning" in self.categories:
+            try:
+                relearn_results = self._relearning.evaluate(
+                    model=model,
+                    forget_data=forget_data,
+                    retain_data=retain_data,
+                    **kwargs,
+                )
+                results["relearning"] = relearn_results
+                overall = relearn_results.get("overall", {})
+                n_passed = overall.get("attacks_passed", 0)
+                n_total = overall.get("attacks_total", 1)
+                scores.append(n_passed / max(n_total, 1))
+            except Exception as e:
+                results["relearning"] = {"error": str(e)}
+                scores.append(0.0)
+
+        # --- Compute overall verdict ---
+        elapsed = time.time() - t0
+
+        if not scores:
+            confidence = 0.0
+        else:
+            confidence = float(sum(scores) / len(scores))
+
+        if self.strict:
+            passed = all(s >= 0.9 for s in scores)
+        else:
+            passed = confidence >= 0.6
+
+        if passed:
+            verdict = "PASS"
+        elif confidence >= 0.3:
+            verdict = "PARTIAL"
+        else:
+            verdict = "FAIL"
+
+        # Build summary
+        summary_parts = []
+        if "mia" in results and "error" not in results["mia"]:
+            mean_auc = results["mia"].get("mia_suite_mean_auc", "N/A")
+            summary_parts.append(f"MIA AUC: {mean_auc:.3f}" if isinstance(mean_auc, float) else f"MIA AUC: {mean_auc}")
+        if "adversarial" in results and "error" not in results["adversarial"]:
+            adv_overall = results["adversarial"].get("overall", {})
+            summary_parts.append(
+                f"Adversarial: {adv_overall.get('tests_passed', 0)}/{adv_overall.get('tests_total', 0)} passed"
+            )
+        if "relearning" in results and "error" not in results["relearning"]:
+            rl_overall = results["relearning"].get("overall", {})
+            summary_parts.append(
+                f"Relearning: {rl_overall.get('attacks_passed', 0)}/{rl_overall.get('attacks_total', 0)} passed"
+            )
+
+        results["verdict"] = verdict
+        results["confidence"] = confidence
+        results["summary"] = " | ".join(summary_parts) if summary_parts else "No tests completed"
+        results["_meta"] = {
+            "categories_evaluated": self.categories,
+            "category_scores": dict(zip(self.categories, scores)),
+            "strict_mode": self.strict,
+            "elapsed_seconds": elapsed,
+        }
+
+        return results

--- a/erasus/metrics/__init__.py
+++ b/erasus/metrics/__init__.py
@@ -38,6 +38,14 @@ from erasus.metrics.privacy.epsilon_delta import EpsilonDeltaMetric
 from erasus.metrics.privacy.privacy_audit import PrivacyAuditMetric
 from erasus.metrics.benchmarks import ErasusBenchmark
 
+# Verification metrics (MIA suite, memorization)
+from erasus.metrics.forgetting.mia_suite import MIASuite
+from erasus.metrics.forgetting.memorization import (
+    ExtractionStrengthMetric,
+    ExactMemorizationMetric,
+    VerbatimMemorizationMetric,
+)
+
 # Register all metrics for CLI / registry-based resolution
 for name, cls in [
     ("accuracy", AccuracyMetric),
@@ -53,6 +61,10 @@ for name, cls in [
     ("time_complexity", TimeComplexityMetric),
     ("memory_usage", MemoryUsageMetric),
     ("dp_evaluation", DPEvaluationMetric),
+    ("mia_suite", MIASuite),
+    ("extraction_strength", ExtractionStrengthMetric),
+    ("exact_memorization", ExactMemorizationMetric),
+    ("verbatim_memorization", VerbatimMemorizationMetric),
 ]:
     try:
         metric_registry.register(name)(cls)
@@ -89,4 +101,9 @@ __all__ = [
     "EpsilonDeltaMetric",
     "PrivacyAuditMetric",
     "ErasusBenchmark",
+    # Verification metrics
+    "MIASuite",
+    "ExtractionStrengthMetric",
+    "ExactMemorizationMetric",
+    "VerbatimMemorizationMetric",
 ]

--- a/erasus/metrics/forgetting/memorization.py
+++ b/erasus/metrics/forgetting/memorization.py
@@ -1,0 +1,307 @@
+"""
+erasus.metrics.forgetting.memorization — Memorization detection metrics.
+
+Implements:
+- Extraction Strength (ES): How much of the forget data can be extracted
+  via generation probing.
+- Exact Memorization (EM): Exact string/tensor match of forget data in
+  model output.
+- Verbatim Memorization: Longest common subsequence ratio between model
+  output and forget data.
+- KnowMem: Knowledge memorization score based on generation overlap.
+
+These metrics go beyond MIA (which tests membership classification) to
+measure whether the model can *reproduce* forget-set content.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from erasus.core.base_metric import BaseMetric
+
+
+class ExtractionStrengthMetric(BaseMetric):
+    """
+    Extraction Strength (ES).
+
+    Measures how much information about forget-set samples can be
+    extracted from the model by querying it.  For classifiers, this is
+    the fraction of forget samples where the model's top-k predictions
+    contain the true label.  For generative models, this would measure
+    output overlap (requires a generate method).
+
+    After successful unlearning, ES should be ≈ random-chance level.
+
+    Parameters
+    ----------
+    top_k : int
+        Number of top predictions to consider (default 1).
+    """
+
+    name = "extraction_strength"
+
+    def __init__(self, top_k: int = 1):
+        self.top_k = top_k
+
+    def compute(
+        self,
+        model: nn.Module,
+        forget_data: Optional[DataLoader] = None,
+        retain_data: Optional[DataLoader] = None,
+        **kwargs: Any,
+    ) -> Dict[str, float]:
+        if forget_data is None:
+            return {"extraction_strength": 0.0}
+
+        device = next(model.parameters()).device
+        model.eval()
+
+        forget_es = self._compute_extraction(model, forget_data, device)
+        results: Dict[str, float] = {
+            "extraction_strength_forget": float(forget_es),
+        }
+
+        if retain_data is not None:
+            retain_es = self._compute_extraction(model, retain_data, device)
+            results["extraction_strength_retain"] = float(retain_es)
+            # Relative ES: how much more extractable is forget vs retain
+            # After good unlearning, this should be ≤ 0
+            results["extraction_strength_gap"] = float(forget_es - retain_es)
+            # Normalised score: 1.0 = perfect (forget ES = 0), 0.0 = no unlearning
+            random_baseline = self.top_k / max(self._infer_num_classes(model, forget_data, device), 1)
+            results["extraction_resistance"] = min(1.0, max(
+                0.0, 1.0 - (forget_es - random_baseline) / max(1.0 - random_baseline, 1e-8)
+            ))
+
+        return results
+
+    def _compute_extraction(
+        self, model: nn.Module, loader: DataLoader, device: torch.device,
+    ) -> float:
+        """Fraction of samples where true label is in top-k predictions."""
+        extracted = 0
+        total = 0
+
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                outputs = model(inputs)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+
+                _, top_k_preds = outputs.topk(min(self.top_k, outputs.size(-1)), dim=-1)
+                for i in range(targets.size(0)):
+                    if targets[i] in top_k_preds[i]:
+                        extracted += 1
+                    total += 1
+
+        return extracted / max(total, 1)
+
+    @staticmethod
+    def _infer_num_classes(
+        model: nn.Module, loader: DataLoader, device: torch.device,
+    ) -> int:
+        """Infer the number of classes from the model output."""
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)):
+                    continue
+                inputs = batch[0].to(device)
+                outputs = model(inputs)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                return outputs.size(-1)
+        return 1
+
+
+class ExactMemorizationMetric(BaseMetric):
+    """
+    Exact Memorization (EM).
+
+    For classifiers: measures the fraction of forget-set samples that
+    the model classifies with the *exact* same confidence ranking as a
+    model that was trained on them (i.e., correct label has highest
+    probability AND confidence exceeds a threshold).
+
+    This is stricter than accuracy — it requires the model to be
+    *confidently correct*, which is the signature of memorization.
+
+    Parameters
+    ----------
+    confidence_threshold : float
+        Minimum softmax probability for the correct class to count as
+        "exactly memorised" (default 0.8).
+    """
+
+    name = "exact_memorization"
+
+    def __init__(self, confidence_threshold: float = 0.8):
+        self.confidence_threshold = confidence_threshold
+
+    def compute(
+        self,
+        model: nn.Module,
+        forget_data: Optional[DataLoader] = None,
+        retain_data: Optional[DataLoader] = None,
+        **kwargs: Any,
+    ) -> Dict[str, float]:
+        if forget_data is None:
+            return {"exact_memorization_forget": 0.0}
+
+        device = next(model.parameters()).device
+        model.eval()
+
+        forget_em, forget_confs = self._compute_em(model, forget_data, device)
+        results: Dict[str, float] = {
+            "exact_memorization_forget": float(forget_em),
+            "exact_memorization_forget_mean_conf": float(np.mean(forget_confs)) if forget_confs else 0.0,
+        }
+
+        if retain_data is not None:
+            retain_em, retain_confs = self._compute_em(model, retain_data, device)
+            results["exact_memorization_retain"] = float(retain_em)
+            results["exact_memorization_retain_mean_conf"] = float(np.mean(retain_confs)) if retain_confs else 0.0
+            results["exact_memorization_gap"] = float(retain_em - forget_em)
+
+        return results
+
+    def _compute_em(
+        self, model: nn.Module, loader: DataLoader, device: torch.device,
+    ) -> Tuple[float, List[float]]:
+        """Fraction of samples that are confidently correctly classified."""
+        memorised = 0
+        total = 0
+        confidences: List[float] = []
+
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                outputs = model(inputs)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+
+                probs = torch.softmax(outputs, dim=-1)
+
+                for i in range(targets.size(0)):
+                    target_prob = probs[i, targets[i]].item()
+                    confidences.append(target_prob)
+                    pred = outputs[i].argmax().item()
+                    if pred == targets[i].item() and target_prob >= self.confidence_threshold:
+                        memorised += 1
+                    total += 1
+
+        return memorised / max(total, 1), confidences
+
+
+class VerbatimMemorizationMetric(BaseMetric):
+    """
+    Verbatim Memorization.
+
+    Measures how closely the model's output distribution matches the
+    training signal for forget-set samples.  Uses the KL divergence
+    between the model's softmax distribution and the one-hot target
+    as a proxy for verbatim memorization.
+
+    Lower KL (closer to zero) = more memorized = worse unlearning.
+    Higher KL = more forgotten = better unlearning.
+
+    Also computes the "memorization score" as the fraction of samples
+    where the model's prediction entropy is below a threshold.
+    """
+
+    name = "verbatim_memorization"
+
+    def __init__(self, entropy_threshold: Optional[float] = None):
+        """
+        Parameters
+        ----------
+        entropy_threshold : float, optional
+            Maximum entropy to consider a sample "memorised".
+            If None, uses ``0.5 * log(num_classes)`` as default.
+        """
+        self.entropy_threshold = entropy_threshold
+
+    def compute(
+        self,
+        model: nn.Module,
+        forget_data: Optional[DataLoader] = None,
+        retain_data: Optional[DataLoader] = None,
+        **kwargs: Any,
+    ) -> Dict[str, float]:
+        if forget_data is None:
+            return {"verbatim_memorization_forget": 0.0}
+
+        device = next(model.parameters()).device
+        model.eval()
+
+        forget_kl, forget_ent, forget_mem = self._analyse(model, forget_data, device)
+        results: Dict[str, float] = {
+            "verbatim_kl_forget": float(np.mean(forget_kl)) if len(forget_kl) else 0.0,
+            "verbatim_entropy_forget": float(np.mean(forget_ent)) if len(forget_ent) else 0.0,
+            "verbatim_memorization_forget": float(forget_mem),
+        }
+
+        if retain_data is not None:
+            retain_kl, retain_ent, retain_mem = self._analyse(model, retain_data, device)
+            results["verbatim_kl_retain"] = float(np.mean(retain_kl)) if len(retain_kl) else 0.0
+            results["verbatim_entropy_retain"] = float(np.mean(retain_ent)) if len(retain_ent) else 0.0
+            results["verbatim_memorization_retain"] = float(retain_mem)
+            results["verbatim_memorization_gap"] = float(retain_mem - forget_mem)
+
+        return results
+
+    def _analyse(
+        self, model: nn.Module, loader: DataLoader, device: torch.device,
+    ) -> Tuple[np.ndarray, np.ndarray, float]:
+        """Compute per-sample KL, entropy, and memorization rate."""
+        kl_divs: list = []
+        entropies: list = []
+        num_classes = None
+        memorised = 0
+        total = 0
+
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                outputs = model(inputs)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+
+                if num_classes is None:
+                    num_classes = outputs.size(-1)
+
+                log_probs = torch.log_softmax(outputs, dim=-1)
+                probs = torch.softmax(outputs, dim=-1)
+
+                # Per-sample entropy
+                ent = -(probs * log_probs).sum(dim=-1)
+                entropies.extend(ent.cpu().tolist())
+
+                # Per-sample KL divergence from one-hot target
+                # KL(one_hot || model) = -log(p_target)
+                for i in range(targets.size(0)):
+                    kl = -log_probs[i, targets[i]].item()
+                    kl_divs.append(kl)
+
+                    # Check memorization
+                    thresh = self.entropy_threshold
+                    if thresh is None and num_classes is not None:
+                        thresh = 0.5 * np.log(num_classes)
+                    if thresh is not None and ent[i].item() < thresh:
+                        memorised += 1
+                    total += 1
+
+        mem_rate = memorised / max(total, 1)
+        return np.array(kl_divs), np.array(entropies), mem_rate

--- a/erasus/metrics/forgetting/mia_suite.py
+++ b/erasus/metrics/forgetting/mia_suite.py
@@ -1,0 +1,472 @@
+"""
+erasus.metrics.forgetting.mia_suite — Full 6-attack MIA suite.
+
+Implements the standard MIA evaluation battery used by OpenUnlearning
+(Locuslab, NeurIPS D&B 2025):
+
+1. LOSS   — per-sample loss as membership signal
+2. ZLib   — loss normalised by zlib compression ratio of the input
+3. Reference — loss ratio between target model and a reference model
+4. GradNorm — L2 norm of per-sample gradients
+5. MinK   — average log-probability of the k% lowest-probability tokens
+6. MinK++ — improved MinK with normalised token-level surprisal
+
+Each attack produces per-sample membership scores. The suite then computes
+AUC and TPR@FPR for the combined battery.
+
+After successful unlearning, AUC for all attacks should be ≈ 0.5.
+"""
+
+from __future__ import annotations
+
+import math
+import zlib
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from erasus.core.base_metric import BaseMetric
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _roc_auc(labels: np.ndarray, scores: np.ndarray) -> float:
+    """Compute AUC via Wilcoxon-Mann-Whitney statistic (no sklearn)."""
+    if len(labels) == 0 or labels.sum() == 0 or labels.sum() == len(labels):
+        return 0.5
+    sorted_idx = np.argsort(-scores)
+    sorted_labels = labels[sorted_idx]
+    n_pos = labels.sum()
+    n_neg = len(labels) - n_pos
+    tp = 0.0
+    auc = 0.0
+    for lab in sorted_labels:
+        if lab == 1:
+            tp += 1
+        else:
+            auc += tp
+    return auc / (n_pos * n_neg)
+
+
+def _tpr_at_fpr(labels: np.ndarray, scores: np.ndarray, target_fpr: float) -> float:
+    """TPR at a given FPR threshold."""
+    n = len(labels)
+    if n == 0:
+        return 0.0
+    thresholds = np.sort(np.unique(scores))[::-1]
+    n_pos = labels.sum()
+    n_neg = n - n_pos
+    if n_pos == 0 or n_neg == 0:
+        return 0.0
+    best_tpr = 0.0
+    for t in thresholds:
+        pred_pos = scores >= t
+        fp = (pred_pos & (labels == 0)).sum()
+        tp = (pred_pos & (labels == 1)).sum()
+        fpr = fp / n_neg
+        if fpr <= target_fpr:
+            best_tpr = max(best_tpr, tp / n_pos)
+    return float(best_tpr)
+
+
+def _collect_per_sample_loss(
+    model: nn.Module, loader: DataLoader, device: torch.device,
+) -> np.ndarray:
+    """Collect per-sample cross-entropy loss."""
+    losses: list = []
+    criterion = nn.CrossEntropyLoss(reduction="none")
+    model.eval()
+    with torch.no_grad():
+        for batch in loader:
+            if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                continue
+            inputs, targets = batch[0].to(device), batch[1].to(device)
+            outputs = model(inputs)
+            if hasattr(outputs, "logits"):
+                outputs = outputs.logits
+            batch_losses = criterion(outputs, targets)
+            losses.append(batch_losses.cpu().numpy())
+    return np.concatenate(losses) if losses else np.array([])
+
+
+# ---------------------------------------------------------------------------
+# Individual attack implementations
+# ---------------------------------------------------------------------------
+
+class _LOSSAttack:
+    """Per-sample loss as membership signal (baseline)."""
+
+    name = "loss"
+
+    @staticmethod
+    def score(
+        model: nn.Module, loader: DataLoader, device: torch.device, **kw: Any,
+    ) -> np.ndarray:
+        losses = _collect_per_sample_loss(model, loader, device)
+        # Lower loss → more likely a member → higher score
+        return -losses
+
+
+class _ZLibAttack:
+    """
+    Loss normalised by zlib compression ratio.
+
+    Intuition: samples that are inherently compressible (low entropy text)
+    will naturally have lower loss.  Normalising by compression length
+    removes this confound, isolating the memorisation signal.
+
+    Reference: Carlini et al., "Extracting Training Data from Large
+    Language Models", USENIX Security 2021.
+    """
+
+    name = "zlib"
+
+    @staticmethod
+    def score(
+        model: nn.Module, loader: DataLoader, device: torch.device, **kw: Any,
+    ) -> np.ndarray:
+        losses = _collect_per_sample_loss(model, loader, device)
+
+        # Compute compression lengths for each sample
+        zlib_lengths: list = []
+        for batch in loader:
+            if not isinstance(batch, (list, tuple)):
+                continue
+            inputs = batch[0]
+            for i in range(inputs.size(0)):
+                raw = inputs[i].numpy().tobytes()
+                compressed_len = len(zlib.compress(raw))
+                zlib_lengths.append(max(compressed_len, 1))
+
+        zlib_arr = np.array(zlib_lengths[: len(losses)], dtype=np.float64)
+        if len(zlib_arr) < len(losses):
+            # Pad if loader iteration produced fewer entries
+            zlib_arr = np.pad(zlib_arr, (0, len(losses) - len(zlib_arr)), constant_values=1)
+
+        # Normalised score: lower loss per compression bit → more memorised
+        return -losses / zlib_arr
+
+
+class _ReferenceAttack:
+    """
+    Loss ratio between target and reference model.
+
+    A reference model (typically the pre-unlearning or pre-trained model)
+    provides a baseline.  If the target model has *much* lower loss on a
+    sample than the reference, it likely memorised that sample.
+
+    After successful unlearning, the ratio should be ≈ 1.
+    """
+
+    name = "reference"
+
+    @staticmethod
+    def score(
+        model: nn.Module,
+        loader: DataLoader,
+        device: torch.device,
+        reference_model: Optional[nn.Module] = None,
+        **kw: Any,
+    ) -> np.ndarray:
+        target_losses = _collect_per_sample_loss(model, loader, device)
+
+        if reference_model is not None:
+            ref_device = next(reference_model.parameters()).device
+            ref_losses = _collect_per_sample_loss(reference_model, loader, ref_device)
+            min_len = min(len(target_losses), len(ref_losses))
+            target_losses = target_losses[:min_len]
+            ref_losses = ref_losses[:min_len]
+            # Ratio: lower target loss relative to reference → more memorised
+            return ref_losses - target_losses
+        else:
+            # Fallback: use loss magnitude (degenerates to LOSS attack)
+            return -target_losses
+
+
+class _GradNormAttack:
+    """
+    Gradient L2-norm as membership signal.
+
+    Members (memorised samples) produce larger gradient norms because
+    the model has specialised parameters for them.  After successful
+    unlearning, gradient norms on forget samples should be small.
+    """
+
+    name = "gradnorm"
+
+    @staticmethod
+    def score(
+        model: nn.Module, loader: DataLoader, device: torch.device, **kw: Any,
+    ) -> np.ndarray:
+        model.eval()  # Keep batchnorm/dropout in eval mode
+        criterion = nn.CrossEntropyLoss()
+        norms: list = []
+
+        for batch in loader:
+            if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                continue
+            inputs, targets = batch[0].to(device), batch[1].to(device)
+
+            # Compute per-sample gradient norms
+            for i in range(inputs.size(0)):
+                model.zero_grad()
+                out = model(inputs[i : i + 1])
+                if hasattr(out, "logits"):
+                    out = out.logits
+                loss = criterion(out, targets[i : i + 1])
+                loss.backward()
+
+                grad_norm = 0.0
+                for p in model.parameters():
+                    if p.grad is not None:
+                        grad_norm += p.grad.norm(2).item() ** 2
+                norms.append(grad_norm ** 0.5)
+
+        return np.array(norms) if norms else np.array([])
+
+
+class _MinKAttack:
+    """
+    Min-K% Prob attack.
+
+    Computes the average log-probability of the k% lowest-probability
+    tokens in each sample.  Memorised samples tend to have higher
+    minimum-k probabilities (the model is confident even on the
+    "hardest" tokens).
+
+    Reference: Shi et al., "Detecting Pretraining Data from Large
+    Language Models", ICLR 2024.
+    """
+
+    name = "mink"
+
+    def __init__(self, k_percent: float = 20.0):
+        self.k_percent = k_percent
+
+    def score(
+        self, model: nn.Module, loader: DataLoader, device: torch.device, **kw: Any,
+    ) -> np.ndarray:
+        model.eval()
+        scores: list = []
+
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                outputs = model(inputs)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+
+                log_probs = torch.log_softmax(outputs, dim=-1)
+
+                for i in range(inputs.size(0)):
+                    # Get log-prob assigned to the correct class
+                    sample_log_probs = log_probs[i]
+
+                    if sample_log_probs.dim() == 1:
+                        # Classification: single vector of log-probs
+                        # Use the sorted log-probs as the "token" distribution
+                        sorted_lp, _ = sample_log_probs.sort()
+                        k = max(1, int(len(sorted_lp) * self.k_percent / 100))
+                        min_k_avg = sorted_lp[:k].mean().item()
+                    else:
+                        # Sequence: (seq_len, vocab) — take min-k across positions
+                        # Get per-position log-prob of the target token
+                        per_pos_lp = sample_log_probs.max(dim=-1).values
+                        sorted_lp, _ = per_pos_lp.sort()
+                        k = max(1, int(len(sorted_lp) * self.k_percent / 100))
+                        min_k_avg = sorted_lp[:k].mean().item()
+
+                    scores.append(min_k_avg)
+
+        return np.array(scores) if scores else np.array([])
+
+
+class _MinKPlusPlusAttack:
+    """
+    Min-K%++ attack (improved MinK).
+
+    Normalises each token's log-probability by the mean and standard
+    deviation across the vocabulary at that position, producing a
+    z-score.  This removes the effect of position difficulty and
+    isolates the memorisation signal.
+
+    Reference: Zhang et al., "Min-K%++: Improved Baseline for Detecting
+    Pre-Training Data from Large Language Models", 2024.
+    """
+
+    name = "mink_pp"
+
+    def __init__(self, k_percent: float = 20.0):
+        self.k_percent = k_percent
+
+    def score(
+        self, model: nn.Module, loader: DataLoader, device: torch.device, **kw: Any,
+    ) -> np.ndarray:
+        model.eval()
+        scores: list = []
+
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                outputs = model(inputs)
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+
+                log_probs = torch.log_softmax(outputs, dim=-1)
+
+                for i in range(inputs.size(0)):
+                    sample_lp = log_probs[i]
+
+                    if sample_lp.dim() == 1:
+                        # Classification: normalise the log-prob vector
+                        mu = sample_lp.mean()
+                        sigma = sample_lp.std().clamp(min=1e-8)
+                        z_scores = (sample_lp - mu) / sigma
+                        sorted_z, _ = z_scores.sort()
+                        k = max(1, int(len(sorted_z) * self.k_percent / 100))
+                        score = sorted_z[:k].mean().item()
+                    else:
+                        # Sequence: normalise per-position
+                        mu = sample_lp.mean(dim=-1, keepdim=True)
+                        sigma = sample_lp.std(dim=-1, keepdim=True).clamp(min=1e-8)
+                        z_scores = (sample_lp - mu) / sigma
+                        # Take the max z-score at each position (correct token)
+                        per_pos_z = z_scores.max(dim=-1).values
+                        sorted_z, _ = per_pos_z.sort()
+                        k = max(1, int(len(sorted_z) * self.k_percent / 100))
+                        score = sorted_z[:k].mean().item()
+
+                    scores.append(score)
+
+        return np.array(scores) if scores else np.array([])
+
+
+# ---------------------------------------------------------------------------
+# Combined MIA Suite
+# ---------------------------------------------------------------------------
+
+class MIASuite(BaseMetric):
+    """
+    Full 6-attack Membership Inference Attack suite.
+
+    Runs all six standard MIA attacks and reports per-attack AUC and
+    TPR@FPR, plus an aggregate score.
+
+    Parameters
+    ----------
+    attacks : list[str], optional
+        Subset of attacks to run. Default: all six.
+        Valid names: ``loss``, ``zlib``, ``reference``, ``gradnorm``,
+        ``mink``, ``mink_pp``.
+    reference_model : nn.Module, optional
+        Reference model for the Reference attack. If not provided,
+        the Reference attack degenerates to the LOSS attack.
+    mink_k_percent : float
+        Percentage for MinK/MinK++ attacks (default 20%).
+    fpr_thresholds : list[float]
+        FPR values at which to report TPR (default [0.01, 0.05, 0.10]).
+
+    Returns
+    -------
+    dict
+        Per-attack AUC and TPR@FPR, plus ``mia_suite_mean_auc`` and
+        ``mia_suite_worst_auc`` (highest AUC = worst unlearning).
+    """
+
+    name = "mia_suite"
+
+    ALL_ATTACKS = ("loss", "zlib", "reference", "gradnorm", "mink", "mink_pp")
+
+    def __init__(
+        self,
+        attacks: Optional[List[str]] = None,
+        reference_model: Optional[nn.Module] = None,
+        mink_k_percent: float = 20.0,
+        fpr_thresholds: Optional[List[float]] = None,
+    ):
+        self.attack_names = list(attacks or self.ALL_ATTACKS)
+        self.reference_model = reference_model
+        self.mink_k_percent = mink_k_percent
+        self.fpr_thresholds = fpr_thresholds or [0.01, 0.05, 0.10]
+
+        self._attacks: Dict[str, Any] = {
+            "loss": _LOSSAttack(),
+            "zlib": _ZLibAttack(),
+            "reference": _ReferenceAttack(),
+            "gradnorm": _GradNormAttack(),
+            "mink": _MinKAttack(k_percent=mink_k_percent),
+            "mink_pp": _MinKPlusPlusAttack(k_percent=mink_k_percent),
+        }
+
+    def compute(
+        self,
+        model: nn.Module,
+        forget_data: Optional[DataLoader] = None,
+        retain_data: Optional[DataLoader] = None,
+        **kwargs: Any,
+    ) -> Dict[str, float]:
+        if forget_data is None or retain_data is None:
+            return {"mia_suite_error": "Both forget_data and retain_data are required"}
+
+        device = next(model.parameters()).device
+        ref_model = kwargs.get("reference_model", self.reference_model)
+
+        results: Dict[str, float] = {}
+        aucs: list = []
+
+        for atk_name in self.attack_names:
+            atk = self._attacks.get(atk_name)
+            if atk is None:
+                results[f"mia_{atk_name}_error"] = -1.0
+                continue
+
+            try:
+                # Score forget (members) and retain (non-members)
+                extra = {}
+                if atk_name == "reference" and ref_model is not None:
+                    extra["reference_model"] = ref_model
+
+                member_scores = atk.score(model, forget_data, device, **extra)
+                nonmember_scores = atk.score(model, retain_data, device, **extra)
+
+                if len(member_scores) == 0 or len(nonmember_scores) == 0:
+                    results[f"mia_{atk_name}_auc"] = 0.5
+                    aucs.append(0.5)
+                    continue
+
+                labels = np.concatenate([
+                    np.ones(len(member_scores)),
+                    np.zeros(len(nonmember_scores)),
+                ])
+                scores = np.concatenate([member_scores, nonmember_scores])
+
+                auc = _roc_auc(labels, scores)
+                results[f"mia_{atk_name}_auc"] = float(auc)
+                aucs.append(auc)
+
+                for fpr_target in self.fpr_thresholds:
+                    tpr = _tpr_at_fpr(labels, scores, fpr_target)
+                    fpr_key = str(fpr_target).replace(".", "")
+                    results[f"mia_{atk_name}_tpr@fpr{fpr_key}"] = float(tpr)
+
+            except Exception as e:
+                results[f"mia_{atk_name}_error"] = -1.0
+                aucs.append(0.5)
+
+        # Aggregate
+        if aucs:
+            results["mia_suite_mean_auc"] = float(np.mean(aucs))
+            results["mia_suite_worst_auc"] = float(np.max(aucs))
+            # Distance from ideal (0.5): lower is better
+            results["mia_suite_forgetting_quality"] = 1.0 - 2 * abs(float(np.mean(aucs)) - 0.5)
+
+        return results

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -1,0 +1,505 @@
+"""
+Tests for the unlearning verification features:
+- MIA Suite (6-attack battery)
+- Memorization metrics (extraction strength, exact memorization, verbatim)
+- Adversarial evaluation (cross-prompt leakage, keyword injection, paraphrase)
+- Relearning robustness (benign finetuning, quantization, LoRA, prompt extraction)
+- Unified verification suite
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+class _TinyModel(nn.Module):
+    """Minimal classifier for fast testing."""
+
+    def __init__(self, input_dim: int = 16, num_classes: int = 4):
+        super().__init__()
+        self.fc1 = nn.Linear(input_dim, 32)
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Linear(32, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.relu(self.fc1(x)))
+
+
+def _make_loader(n: int = 32, dim: int = 16, n_classes: int = 4, bs: int = 8):
+    x = torch.randn(n, dim)
+    y = torch.randint(0, n_classes, (n,))
+    return DataLoader(TensorDataset(x, y), batch_size=bs, shuffle=False)
+
+
+@pytest.fixture
+def model():
+    m = _TinyModel()
+    # Train briefly so it has some signal
+    loader = _make_loader(64)
+    opt = torch.optim.SGD(m.parameters(), lr=0.1)
+    m.train()
+    for _ in range(5):
+        for x, y in loader:
+            opt.zero_grad()
+            nn.functional.cross_entropy(m(x), y).backward()
+            opt.step()
+    m.eval()
+    return m
+
+
+@pytest.fixture
+def forget_loader():
+    return _make_loader(32, dim=16, n_classes=4, bs=8)
+
+
+@pytest.fixture
+def retain_loader():
+    return _make_loader(64, dim=16, n_classes=4, bs=8)
+
+
+# ===================================================================
+# MIA Suite
+# ===================================================================
+
+class TestMIASuite:
+    """Tests for the 6-attack MIA suite."""
+
+    def test_all_attacks_run(self, model, forget_loader, retain_loader):
+        from erasus.metrics.forgetting.mia_suite import MIASuite
+
+        suite = MIASuite()
+        results = suite.compute(model, forget_loader, retain_loader)
+
+        # Should have AUC for each attack
+        for atk in MIASuite.ALL_ATTACKS:
+            key = f"mia_{atk}_auc"
+            assert key in results or f"mia_{atk}_error" in results, f"Missing {key}"
+
+        # Should have aggregate scores
+        assert "mia_suite_mean_auc" in results
+        assert "mia_suite_worst_auc" in results
+        assert "mia_suite_forgetting_quality" in results
+
+    def test_auc_in_valid_range(self, model, forget_loader, retain_loader):
+        from erasus.metrics.forgetting.mia_suite import MIASuite
+
+        suite = MIASuite()
+        results = suite.compute(model, forget_loader, retain_loader)
+
+        for key, value in results.items():
+            if "auc" in key and isinstance(value, float):
+                assert 0.0 <= value <= 1.0, f"{key}={value} out of [0, 1]"
+
+    def test_subset_attacks(self, model, forget_loader, retain_loader):
+        from erasus.metrics.forgetting.mia_suite import MIASuite
+
+        suite = MIASuite(attacks=["loss", "zlib"])
+        results = suite.compute(model, forget_loader, retain_loader)
+
+        assert "mia_loss_auc" in results
+        assert "mia_zlib_auc" in results
+        # Should NOT have gradnorm (not requested)
+        assert "mia_gradnorm_auc" not in results
+
+    def test_with_reference_model(self, model, forget_loader, retain_loader):
+        from erasus.metrics.forgetting.mia_suite import MIASuite
+
+        ref = _TinyModel()  # Untrained reference
+        suite = MIASuite(attacks=["reference"], reference_model=ref)
+        results = suite.compute(model, forget_loader, retain_loader)
+
+        assert "mia_reference_auc" in results
+
+    def test_tpr_at_fpr_reported(self, model, forget_loader, retain_loader):
+        from erasus.metrics.forgetting.mia_suite import MIASuite
+
+        suite = MIASuite(attacks=["loss"], fpr_thresholds=[0.05])
+        results = suite.compute(model, forget_loader, retain_loader)
+
+        assert "mia_loss_tpr@fpr005" in results
+
+    def test_empty_loaders(self, model):
+        from erasus.metrics.forgetting.mia_suite import MIASuite
+
+        empty = DataLoader(TensorDataset(torch.empty(0, 16), torch.empty(0, dtype=torch.long)), batch_size=1)
+        suite = MIASuite(attacks=["loss"])
+        results = suite.compute(model, empty, empty)
+        # Should not crash, should return 0.5 AUC
+        assert "mia_loss_auc" in results
+
+
+# ===================================================================
+# Memorization Metrics
+# ===================================================================
+
+class TestExtractionStrength:
+    def test_basic(self, model, forget_loader, retain_loader):
+        from erasus.metrics.forgetting.memorization import ExtractionStrengthMetric
+
+        metric = ExtractionStrengthMetric(top_k=1)
+        results = metric.compute(model, forget_loader, retain_loader)
+
+        assert "extraction_strength_forget" in results
+        assert "extraction_strength_retain" in results
+        assert "extraction_strength_gap" in results
+        assert "extraction_resistance" in results
+        assert 0.0 <= results["extraction_resistance"] <= 1.0
+
+    def test_top_k(self, model, forget_loader, retain_loader):
+        from erasus.metrics.forgetting.memorization import ExtractionStrengthMetric
+
+        m1 = ExtractionStrengthMetric(top_k=1).compute(model, forget_loader, retain_loader)
+        m2 = ExtractionStrengthMetric(top_k=3).compute(model, forget_loader, retain_loader)
+
+        # top-3 ES should be >= top-1 ES
+        assert m2["extraction_strength_forget"] >= m1["extraction_strength_forget"]
+
+
+class TestExactMemorization:
+    def test_basic(self, model, forget_loader, retain_loader):
+        from erasus.metrics.forgetting.memorization import ExactMemorizationMetric
+
+        metric = ExactMemorizationMetric(confidence_threshold=0.5)
+        results = metric.compute(model, forget_loader, retain_loader)
+
+        assert "exact_memorization_forget" in results
+        assert "exact_memorization_retain" in results
+        assert "exact_memorization_gap" in results
+        assert 0.0 <= results["exact_memorization_forget"] <= 1.0
+
+    def test_high_threshold(self, model, forget_loader, retain_loader):
+        from erasus.metrics.forgetting.memorization import ExactMemorizationMetric
+
+        low = ExactMemorizationMetric(confidence_threshold=0.3).compute(model, forget_loader, retain_loader)
+        high = ExactMemorizationMetric(confidence_threshold=0.99).compute(model, forget_loader, retain_loader)
+
+        # Higher threshold → fewer samples counted as memorised
+        assert high["exact_memorization_forget"] <= low["exact_memorization_forget"]
+
+
+class TestVerbatimMemorization:
+    def test_basic(self, model, forget_loader, retain_loader):
+        from erasus.metrics.forgetting.memorization import VerbatimMemorizationMetric
+
+        metric = VerbatimMemorizationMetric()
+        results = metric.compute(model, forget_loader, retain_loader)
+
+        assert "verbatim_kl_forget" in results
+        assert "verbatim_entropy_forget" in results
+        assert "verbatim_memorization_forget" in results
+        assert "verbatim_kl_retain" in results
+
+
+# ===================================================================
+# Adversarial Evaluation
+# ===================================================================
+
+class TestCrossPromptLeakage:
+    def test_runs(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.adversarial import CrossPromptLeakageTest
+
+        test = CrossPromptLeakageTest(n_pairs=10)
+        result = test.run(model, forget_loader, retain_loader)
+
+        assert "test" in result
+        assert result["test"] == "cross_prompt_leakage"
+        assert "leakage_rate" in result
+        assert "passed" in result
+        assert 0.0 <= result["leakage_rate"] <= 1.0
+
+    def test_custom_threshold(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.adversarial import CrossPromptLeakageTest
+
+        strict = CrossPromptLeakageTest(change_threshold=0.001)
+        result = strict.run(model, forget_loader, retain_loader)
+        assert "leakage_rate" in result
+
+
+class TestKeywordInjection:
+    def test_runs(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.adversarial import KeywordInjectionTest
+
+        test = KeywordInjectionTest(injection_strengths=[0.05, 0.1])
+        result = test.run(model, forget_loader, retain_loader)
+
+        assert "test" in result
+        assert result["test"] == "keyword_injection"
+        assert "baseline_retain_accuracy" in result
+        assert "worst_accuracy_drop" in result
+        assert "passed" in result
+
+    def test_zero_injection_no_change(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.adversarial import KeywordInjectionTest
+
+        test = KeywordInjectionTest(injection_strengths=[0.0])
+        result = test.run(model, forget_loader, retain_loader)
+        # Zero injection should have approximately zero drop
+        assert abs(result.get("injection_alpha_0.00_drop", 0)) < 0.05
+
+
+class TestParaphraseRobustness:
+    def test_runs(self, model, forget_loader):
+        from erasus.evaluation.adversarial import ParaphraseRobustnessTest
+
+        test = ParaphraseRobustnessTest(noise_levels=[0.01], n_perturbations=2)
+        result = test.run(model, forget_loader)
+
+        assert "test" in result
+        assert result["test"] == "paraphrase_robustness"
+        assert "baseline_forget_accuracy" in result
+        assert "max_accuracy_recovery" in result
+        assert "permutation_accuracy" in result
+        assert "scaling_accuracy" in result
+        assert "passed" in result
+
+
+class TestAdversarialEvaluator:
+    def test_runs_all(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.adversarial import AdversarialEvaluator
+
+        evaluator = AdversarialEvaluator()
+        report = evaluator.evaluate(model, forget_loader, retain_loader)
+
+        assert "cross_prompt" in report
+        assert "keyword_injection" in report
+        assert "paraphrase" in report
+        assert "overall" in report
+        assert "tests_passed" in report["overall"]
+        assert "verdict" in report["overall"]
+
+    def test_subset(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.adversarial import AdversarialEvaluator
+
+        evaluator = AdversarialEvaluator(tests=["cross_prompt"])
+        report = evaluator.evaluate(model, forget_loader, retain_loader)
+
+        assert "cross_prompt" in report
+        assert "keyword_injection" not in report
+
+
+# ===================================================================
+# Relearning Robustness
+# ===================================================================
+
+class TestBenignFinetuning:
+    def test_runs(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.relearning import BenignFinetuningAttack
+
+        attack = BenignFinetuningAttack(epochs=1, lr=1e-3)
+        result = attack.run(model, forget_loader, retain_loader)
+
+        assert result["test"] == "benign_finetuning"
+        assert "pre_forget_accuracy" in result
+        assert "post_forget_accuracy" in result
+        assert "forget_accuracy_recovery" in result
+        assert "passed" in result
+
+    def test_does_not_modify_original(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.relearning import BenignFinetuningAttack
+
+        # Snapshot original params
+        original_params = {n: p.clone() for n, p in model.named_parameters()}
+
+        attack = BenignFinetuningAttack(epochs=1)
+        attack.run(model, forget_loader, retain_loader)
+
+        # Original model should be unchanged
+        for n, p in model.named_parameters():
+            assert torch.equal(p, original_params[n]), f"Original model param {n} was modified"
+
+
+class TestQuantization:
+    def test_runs(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.relearning import QuantizationAttack
+
+        attack = QuantizationAttack(bit_widths=[8])
+        result = attack.run(model, forget_loader, retain_loader)
+
+        assert result["test"] == "quantization"
+        assert "quant_8bit_forget_accuracy" in result
+        assert "worst_recovery" in result
+        assert "passed" in result
+
+    def test_multiple_bit_widths(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.relearning import QuantizationAttack
+
+        attack = QuantizationAttack(bit_widths=[8, 4])
+        result = attack.run(model, forget_loader, retain_loader)
+
+        assert "quant_8bit_forget_accuracy" in result
+        assert "quant_4bit_forget_accuracy" in result
+
+
+class TestLoRARelearning:
+    def test_runs(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.relearning import LoRARelearningAttack
+
+        attack = LoRARelearningAttack(rank=2, epochs=1, lr=1e-3)
+        result = attack.run(model, forget_loader, retain_loader)
+
+        assert result["test"] == "lora_relearning"
+        assert "lora_params" in result
+        assert "forget_accuracy_recovery" in result
+        assert "passed" in result
+
+    def test_does_not_modify_original(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.relearning import LoRARelearningAttack
+
+        original_params = {n: p.clone() for n, p in model.named_parameters()}
+
+        attack = LoRARelearningAttack(rank=2, epochs=1)
+        attack.run(model, forget_loader, retain_loader)
+
+        for n, p in model.named_parameters():
+            assert torch.equal(p, original_params[n]), f"Original model param {n} was modified"
+
+
+class TestPromptExtraction:
+    def test_runs(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.relearning import PromptExtractionAttack
+
+        attack = PromptExtractionAttack(n_pgd_steps=3, epsilon=0.05)
+        result = attack.run(model, forget_loader, retain_loader)
+
+        assert result["test"] == "prompt_extraction"
+        assert "pgd_accuracy" in result
+        assert "interpolation_accuracy" in result
+        assert "amplification_accuracy" in result
+        assert "worst_recovery" in result
+        assert "passed" in result
+
+
+class TestRelearningEvaluator:
+    def test_runs_all(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.relearning import RelearningRobustnessEvaluator
+
+        evaluator = RelearningRobustnessEvaluator(
+            benign_finetuning_kwargs={"epochs": 1},
+            lora_relearning_kwargs={"rank": 2, "epochs": 1},
+            prompt_extraction_kwargs={"n_pgd_steps": 2},
+        )
+        report = evaluator.evaluate(model, forget_loader, retain_loader)
+
+        assert "benign_finetuning" in report
+        assert "quantization" in report
+        assert "lora_relearning" in report
+        assert "prompt_extraction" in report
+        assert "overall" in report
+        assert "verdict" in report["overall"]
+
+    def test_subset(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.relearning import RelearningRobustnessEvaluator
+
+        evaluator = RelearningRobustnessEvaluator(attacks=["quantization"])
+        report = evaluator.evaluate(model, forget_loader, retain_loader)
+
+        assert "quantization" in report
+        assert "benign_finetuning" not in report
+
+
+# ===================================================================
+# Unified Verification Suite
+# ===================================================================
+
+class TestVerificationSuite:
+    def test_runs_all_categories(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.verification_suite import UnlearningVerificationSuite
+
+        suite = UnlearningVerificationSuite(
+            relearning_kwargs={
+                "benign_finetuning_kwargs": {"epochs": 1},
+                "lora_relearning_kwargs": {"rank": 2, "epochs": 1},
+                "prompt_extraction_kwargs": {"n_pgd_steps": 2},
+            },
+        )
+        report = suite.verify(model, forget_loader, retain_loader)
+
+        assert "verdict" in report
+        assert report["verdict"] in ("PASS", "PARTIAL", "FAIL")
+        assert "confidence" in report
+        assert 0.0 <= report["confidence"] <= 1.0
+        assert "summary" in report
+        assert "_meta" in report
+        assert "mia" in report
+        assert "memorization" in report
+        assert "adversarial" in report
+        assert "relearning" in report
+
+    def test_subset_categories(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.verification_suite import UnlearningVerificationSuite
+
+        suite = UnlearningVerificationSuite(categories=["mia", "memorization"])
+        report = suite.verify(model, forget_loader, retain_loader)
+
+        assert "mia" in report
+        assert "memorization" in report
+        assert "adversarial" not in report
+        assert "relearning" not in report
+
+    def test_strict_mode(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.verification_suite import UnlearningVerificationSuite
+
+        suite = UnlearningVerificationSuite(
+            categories=["mia"],
+            strict=True,
+        )
+        report = suite.verify(model, forget_loader, retain_loader)
+
+        # Strict mode requires all scores >= 0.9
+        assert report["verdict"] in ("PASS", "PARTIAL", "FAIL")
+
+    def test_meta_has_timing(self, model, forget_loader, retain_loader):
+        from erasus.evaluation.verification_suite import UnlearningVerificationSuite
+
+        suite = UnlearningVerificationSuite(categories=["mia"])
+        report = suite.verify(model, forget_loader, retain_loader)
+
+        assert report["_meta"]["elapsed_seconds"] > 0
+        assert "mia" in report["_meta"]["category_scores"]
+
+
+# ===================================================================
+# Registry integration
+# ===================================================================
+
+class TestRegistryIntegration:
+    def test_new_metrics_registered(self):
+        from erasus.core.registry import metric_registry
+
+        for name in ["mia_suite", "extraction_strength", "exact_memorization", "verbatim_memorization"]:
+            cls = metric_registry.get(name)
+            assert cls is not None, f"{name} not registered"
+
+    def test_mia_suite_via_registry(self, model, forget_loader, retain_loader):
+        from erasus.core.registry import metric_registry
+
+        cls = metric_registry.get("mia_suite")
+        instance = cls(attacks=["loss"])
+        results = instance.compute(model, forget_loader, retain_loader)
+        assert "mia_loss_auc" in results
+
+    def test_imports(self):
+        from erasus.metrics import MIASuite, ExtractionStrengthMetric, ExactMemorizationMetric, VerbatimMemorizationMetric
+        from erasus.evaluation import (
+            AdversarialEvaluator,
+            CrossPromptLeakageTest,
+            KeywordInjectionTest,
+            ParaphraseRobustnessTest,
+            RelearningRobustnessEvaluator,
+            BenignFinetuningAttack,
+            QuantizationAttack,
+            LoRARelearningAttack,
+            PromptExtractionAttack,
+            UnlearningVerificationSuite,
+        )
+        # All imports succeeded
+        assert MIASuite is not None
+        assert AdversarialEvaluator is not None
+        assert UnlearningVerificationSuite is not None


### PR DESCRIPTION
Implement adversarial evaluation and relearning robustness testing to verify whether unlearning actually works, beyond standard benchmarks.

New modules:
- 6-attack MIA suite (LOSS, ZLib, Reference, GradNorm, MinK, MinK++)
- Memorization metrics (Extraction Strength, Exact Memorization, Verbatim)
- Adversarial tests (cross-prompt leakage, keyword injection, paraphrase robustness)
- Relearning attacks (benign fine-tuning, quantization, LoRA relearning, PGD extraction)
- Unified UnlearningVerificationSuite with PASS/PARTIAL/FAIL verdict

Also adds ROADMAP.md with deep research analysis and CLAUDE.md for contributor onboarding.

34 new tests, all passing. Zero regressions on existing suite.

## Description

<!-- What does this PR do? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Test addition

## Changes Made

<!-- List the specific changes -->
-
-
-

## Testing

- [ ] All existing tests pass (`python -m pytest tests/ -v`)
- [ ] New tests added for new functionality
- [ ] Tested manually

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review of code completed
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes introduced
