### PR TITLE
fix: Resolve critical code quality issues from issue #9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [torch, numpy]
+        args: [--ignore-missing-imports, --no-strict-optional]
+        pass_filenames: false
+        entry: mypy erasus/core/ erasus/utils/batch.py
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+        args: [--maxkb=500]

--- a/erasus/selectors/ensemble/voting.py
+++ b/erasus/selectors/ensemble/voting.py
@@ -7,14 +7,17 @@ the most universally "important" or "difficult" examples.
 
 from __future__ import annotations
 
-from typing import Any, List, Dict
+import logging
+from collections import Counter
+from typing import Any, Dict, List
 
 import torch.nn as nn
 from torch.utils.data import DataLoader
-from collections import Counter
 
 from erasus.core.base_selector import BaseSelector
 from erasus.core.registry import selector_registry, Registry
+
+logger = logging.getLogger(__name__)
 
 
 @selector_registry.register("voting")
@@ -53,7 +56,7 @@ class VotingSelector(BaseSelector):
                 all_votes.extend(indices)
                 
             except Exception as e:
-                print(f"Warning: VotingSelector failed to run '{name}': {e}")
+                logger.warning("VotingSelector failed to run '%s': %s", name, e)
                 continue
                 
         if not all_votes:

--- a/erasus/selectors/geometry_based/glister.py
+++ b/erasus/selectors/geometry_based/glister.py
@@ -7,6 +7,7 @@ Selects subset that maximizes log-likelihood on a validation set (approximated b
 
 from __future__ import annotations
 
+import logging
 from typing import Any, List
 
 import numpy as np
@@ -15,7 +16,10 @@ import torch.nn as nn
 from torch.utils.data import DataLoader
 
 from erasus.core.base_selector import BaseSelector
+from erasus.core.exceptions import SelectorError
 from erasus.core.registry import selector_registry
+
+logger = logging.getLogger(__name__)
 
 
 @selector_registry.register("glister")
@@ -35,10 +39,11 @@ class GlisterSelector(BaseSelector):
     ) -> List[int]:
         
         if val_loader is None:
-            print("Warning: Glister requires 'val_loader'. Returning Random.")
-            # Fallback
-            from erasus.selectors.random_selector import RandomSelector
-            return RandomSelector().select(model, data_loader, k)
+            raise SelectorError(
+                "GlisterSelector requires a 'val_loader' argument — a DataLoader "
+                "for the validation set used to approximate generalization. Pass it "
+                "as: selector.select(model, loader, k, val_loader=val_loader)"
+            )
 
         # Implementation of greedy selection based on gradient similarity with validation set
         # Often simplified to: Gradient Matching between Train and Validation.

--- a/erasus/selectors/geometry_based/k_center.py
+++ b/erasus/selectors/geometry_based/k_center.py
@@ -1,15 +1,10 @@
 """
-K-Center Selector Alias.
+K-Center Selector — backwards-compatible alias.
 
-This module is an alias for `erasus.selectors.geometry_based.kcenter`.
+The canonical implementation lives in ``kcenter.py`` and is registered
+as ``"kcenter"``.  This module re-exports ``KCenterSelector`` so that
+``from erasus.selectors.geometry_based.k_center import KCenterSelector``
+continues to work.
 """
 
-from erasus.selectors.geometry_based.kcenter import KCenterSelector
-from erasus.core.registry import selector_registry
-
-# Re-register under legacy name just in case, though kcenter registers itself as "kcenter".
-# If "k_center" string is needed, register it.
-try:
-    selector_registry.register("k_center")(KCenterSelector)
-except ValueError:
-    pass
+from erasus.selectors.geometry_based.kcenter import KCenterSelector  # noqa: F401

--- a/erasus/selectors/geometry_based/submodular.py
+++ b/erasus/selectors/geometry_based/submodular.py
@@ -7,6 +7,7 @@ ensuring diversity and representativeness.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, List
 
 import numpy as np
@@ -16,6 +17,8 @@ from torch.utils.data import DataLoader
 
 from erasus.core.base_selector import BaseSelector
 from erasus.core.registry import selector_registry
+
+logger = logging.getLogger(__name__)
 
 
 @selector_registry.register("submodular")
@@ -45,7 +48,7 @@ class SubmodularSelector(BaseSelector):
         # Similarity matrix [N, N] - Expensive for large N!
         # For N > 5000, consider random subsampling or batching.
         if n_samples > 2000:
-             print("Warning: Submodular selection is O(N^2). Subsampling to 2000 for efficiency.")
+             logger.warning("Submodular selection is O(N^2). Subsampling to 2000 for efficiency.")
              indices = np.random.choice(n_samples, 2000, replace=False)
              embeddings = embeddings[indices]
              mapping = {i: old for i, old in enumerate(indices)}

--- a/erasus/selectors/learning_based/data_shapley.py
+++ b/erasus/selectors/learning_based/data_shapley.py
@@ -8,6 +8,7 @@ Approximated via TMC-Shapley or G-Shapley (Gradient).
 
 from __future__ import annotations
 
+import logging
 from typing import Any, List
 
 import numpy as np
@@ -16,7 +17,10 @@ import torch.nn as nn
 from torch.utils.data import DataLoader
 
 from erasus.core.base_selector import BaseSelector
+from erasus.core.exceptions import SelectorError
 from erasus.core.registry import selector_registry
+
+logger = logging.getLogger(__name__)
 
 
 @selector_registry.register("data_shapley")
@@ -40,6 +44,10 @@ class DataShapleySelector(BaseSelector):
              top_k = np.argsort(precomputed_values)[-k:].tolist()
              return [int(i) for i in top_k]
 
-        print("Warning: Data Shapley requires 'precomputed_values' or massive compute. Returning Random.")
-        from erasus.selectors.random_selector import RandomSelector
-        return RandomSelector().select(model, data_loader, k)
+        raise SelectorError(
+            "DataShapleySelector requires 'precomputed_values' — a list of "
+            "per-sample Shapley values. Computing these from scratch requires "
+            "O(N * M) model retrainings and is not done automatically. "
+            "Pre-compute values externally and pass as: "
+            "selector.select(model, loader, k, precomputed_values=[...])"
+        )

--- a/erasus/selectors/learning_based/forgetting_events.py
+++ b/erasus/selectors/learning_based/forgetting_events.py
@@ -9,14 +9,18 @@ Reference: Toneva et al., "An Empirical Study of Example Forgetting during Deep 
 
 from __future__ import annotations
 
-from typing import Any, List, Dict
+import logging
+from typing import Any, Dict, List
 
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
 from erasus.core.base_selector import BaseSelector
+from erasus.core.exceptions import SelectorError
 from erasus.core.registry import selector_registry
+
+logger = logging.getLogger(__name__)
 
 
 @selector_registry.register("forgetting_events")
@@ -39,13 +43,13 @@ class ForgettingEventsSelector(BaseSelector):
     ) -> List[int]:
         
         if forgetting_stats is None:
-            # We cannot compute this from a static checkpoint.
-            # We implemented a stub warning previously.
-            # Now explicitly failing or mocking.
-            print("Warning: ForgettingEventsSelector requires 'forgetting_stats' dictionary (idx -> count). Returning Random.")
-            import random
-            n = len(data_loader.dataset)
-            return random.sample(range(n), min(k, n))
+            raise SelectorError(
+                "ForgettingEventsSelector requires a 'forgetting_stats' dictionary "
+                "mapping sample index -> forgetting event count. This cannot be "
+                "computed from a static checkpoint — it must be collected during "
+                "training. Pass it as: selector.select(model, loader, k, "
+                "forgetting_stats={0: 3, 1: 0, ...})"
+            )
 
         # Sort by count descending
         sorted_indices = sorted(forgetting_stats.keys(), key=lambda i: forgetting_stats[i], reverse=True)

--- a/erasus/selectors/learning_based/valuation_network.py
+++ b/erasus/selectors/learning_based/valuation_network.py
@@ -7,13 +7,20 @@ Requires a pre-trained Valuation Network that accepts (input, label) pairs and o
 Reference: "Data Valuation using Reinforcement Learning" (Yoon et al., ICML 2020)
 """
 from __future__ import annotations
+
+import logging
 from typing import Any, List
+
+import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
-import numpy as np
+
 from erasus.core.base_selector import BaseSelector
+from erasus.core.exceptions import SelectorError
 from erasus.core.registry import selector_registry
+
+logger = logging.getLogger(__name__)
 
 @selector_registry.register("valuation_network")
 class ValuationNetworkSelector(BaseSelector):
@@ -23,9 +30,11 @@ class ValuationNetworkSelector(BaseSelector):
     
     def select(self, model: nn.Module, data_loader: DataLoader, k: int, val_net: nn.Module = None, **kwargs) -> List[int]:
         if val_net is None:
-             print("Warning: ValuationNetworkSelector requires 'val_net' (an auxiliary scoring model). Returning Random fallback.")
-             from erasus.selectors.random_selector import RandomSelector
-             return RandomSelector().select(model, data_loader, k)
+            raise SelectorError(
+                "ValuationNetworkSelector requires a 'val_net' argument — a trained "
+                "auxiliary model that scores (input, label) pairs. Pass it as: "
+                "selector.select(model, loader, k, val_net=my_val_net)"
+            )
         
         device = next(val_net.parameters()).device
         val_net.eval()

--- a/erasus/utils/__init__.py
+++ b/erasus/utils/__init__.py
@@ -27,6 +27,7 @@ from erasus.utils.distributed import (
     broadcast_object,
 )
 
+from erasus.utils.batch import unpack_batch
 from erasus.utils.profiling import UnlearningProfiler, profile_section, profile_model_memory
 from erasus.utils.reproducibility import make_reproducible, ExperimentSnapshot
 
@@ -58,6 +59,8 @@ __all__ = [
     "UnlearningProfiler",
     "profile_section",
     "profile_model_memory",
+    # batch
+    "unpack_batch",
     # reproducibility
     "make_reproducible",
     "ExperimentSnapshot",

--- a/erasus/utils/batch.py
+++ b/erasus/utils/batch.py
@@ -1,0 +1,61 @@
+"""
+Batch unpacking utilities.
+
+Centralises the logic for extracting inputs, labels, and optional extras
+from DataLoader batches, which appear in at least three different formats
+across the codebase.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Tuple
+
+import torch
+
+
+def unpack_batch(
+    batch: Any,
+    device: Optional[torch.device] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """
+    Extract ``(inputs, labels)`` from a DataLoader batch.
+
+    Supports three common formats:
+
+    1. ``(inputs, labels, ...)`` — tuple/list with >= 2 elements
+    2. ``(inputs,)`` — single-element tuple (labels=None)
+    3. ``dict`` with ``"input_ids"``/``"inputs"`` and optional ``"labels"``
+
+    Parameters
+    ----------
+    batch : Any
+        A single batch from a DataLoader.
+    device : torch.device, optional
+        If given, tensors are moved to this device.
+
+    Returns
+    -------
+    tuple[Tensor, Tensor | None]
+        ``(inputs, labels)`` where labels may be None.
+    """
+    if isinstance(batch, dict):
+        inputs = batch.get("input_ids", batch.get("inputs"))
+        if inputs is None:
+            raise ValueError(
+                "Dict batch must contain 'input_ids' or 'inputs' key. "
+                f"Got keys: {list(batch.keys())}"
+            )
+        labels = batch.get("labels")
+    elif isinstance(batch, (list, tuple)):
+        inputs = batch[0]
+        labels = batch[1] if len(batch) > 1 else None
+    else:
+        inputs = batch
+        labels = None
+
+    if device is not None:
+        inputs = inputs.to(device)
+        if labels is not None:
+            labels = labels.to(device)
+
+    return inputs, labels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,23 @@ target-version = "py39"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v --tb=short"
+
+[tool.coverage.run]
+source = ["erasus"]
+omit = ["erasus/visualization/*", "erasus/cli/*"]
+
+[tool.coverage.report]
+fail_under = 50
+show_missing = true
+skip_empty = true
 markers = [
     "real_models: integration tests that download/use real HuggingFace models (deselect with: -m 'not real_models')",
 ]
+
+[tool.mypy]
+python_version = "3.9"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true
+check_untyped_defs = true
+disallow_untyped_defs = false

--- a/tests/unit/test_issue9.py
+++ b/tests/unit/test_issue9.py
@@ -1,0 +1,154 @@
+"""
+Tests for issue #9 fixes: silent fallbacks, batch unpacking, selector dedup.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+def _make_loader(n: int = 50, dim: int = 16, n_classes: int = 4) -> DataLoader:
+    return DataLoader(
+        TensorDataset(torch.randn(n, dim), torch.randint(0, n_classes, (n,))),
+        batch_size=16,
+    )
+
+
+def _tiny_model() -> nn.Module:
+    return nn.Sequential(nn.Linear(16, 32), nn.ReLU(), nn.Linear(32, 4))
+
+
+# ======================================================================
+# Silent fallback fixes — selectors now raise SelectorError
+# ======================================================================
+
+
+class TestSilentFallbacksFixed:
+    def test_valuation_network_raises(self):
+        from erasus.core.exceptions import SelectorError
+        from erasus.selectors.learning_based.valuation_network import ValuationNetworkSelector
+
+        sel = ValuationNetworkSelector()
+        with pytest.raises(SelectorError, match="val_net"):
+            sel.select(_tiny_model(), _make_loader(), k=5)
+
+    def test_forgetting_events_raises(self):
+        from erasus.core.exceptions import SelectorError
+        from erasus.selectors.learning_based.forgetting_events import ForgettingEventsSelector
+
+        sel = ForgettingEventsSelector()
+        with pytest.raises(SelectorError, match="forgetting_stats"):
+            sel.select(_tiny_model(), _make_loader(), k=5)
+
+    def test_data_shapley_raises(self):
+        from erasus.core.exceptions import SelectorError
+        from erasus.selectors.learning_based.data_shapley import DataShapleySelector
+
+        sel = DataShapleySelector()
+        with pytest.raises(SelectorError, match="precomputed_values"):
+            sel.select(_tiny_model(), _make_loader(), k=5)
+
+    def test_glister_raises(self):
+        from erasus.core.exceptions import SelectorError
+        from erasus.selectors.geometry_based.glister import GlisterSelector
+
+        sel = GlisterSelector()
+        with pytest.raises(SelectorError, match="val_loader"):
+            sel.select(_tiny_model(), _make_loader(), k=5)
+
+    def test_forgetting_events_works_with_stats(self):
+        from erasus.selectors.learning_based.forgetting_events import ForgettingEventsSelector
+
+        sel = ForgettingEventsSelector()
+        stats = {0: 5, 1: 3, 2: 8, 3: 1, 4: 10}
+        result = sel.select(_tiny_model(), _make_loader(), k=3, forgetting_stats=stats)
+        assert len(result) == 3
+        assert result[0] == 4  # highest count
+
+    def test_data_shapley_works_with_values(self):
+        from erasus.selectors.learning_based.data_shapley import DataShapleySelector
+
+        sel = DataShapleySelector()
+        values = [0.1, 0.9, 0.5, 0.3, 0.7]
+        result = sel.select(_tiny_model(), _make_loader(5), k=2, precomputed_values=values)
+        assert len(result) == 2
+        assert 1 in result  # highest value
+
+
+# ======================================================================
+# Batch unpacking utility
+# ======================================================================
+
+
+class TestUnpackBatch:
+    def test_tuple_batch(self):
+        from erasus.utils.batch import unpack_batch
+
+        batch = (torch.randn(4, 16), torch.randint(0, 4, (4,)))
+        inputs, labels = unpack_batch(batch)
+        assert inputs.shape == (4, 16)
+        assert labels.shape == (4,)
+
+    def test_single_tensor_batch(self):
+        from erasus.utils.batch import unpack_batch
+
+        batch = (torch.randn(4, 16),)
+        inputs, labels = unpack_batch(batch)
+        assert inputs.shape == (4, 16)
+        assert labels is None
+
+    def test_dict_batch(self):
+        from erasus.utils.batch import unpack_batch
+
+        batch = {"input_ids": torch.randn(4, 16), "labels": torch.randint(0, 4, (4,))}
+        inputs, labels = unpack_batch(batch)
+        assert inputs.shape == (4, 16)
+        assert labels.shape == (4,)
+
+    def test_device_transfer(self):
+        from erasus.utils.batch import unpack_batch
+
+        batch = (torch.randn(4, 16), torch.randint(0, 4, (4,)))
+        inputs, labels = unpack_batch(batch, device=torch.device("cpu"))
+        assert inputs.device == torch.device("cpu")
+
+    def test_bad_dict_raises(self):
+        from erasus.utils.batch import unpack_batch
+
+        with pytest.raises(ValueError, match="input_ids"):
+            unpack_batch({"foo": torch.randn(4, 16)})
+
+
+# ======================================================================
+# Selector deduplication
+# ======================================================================
+
+
+class TestSelectorDedup:
+    def test_kcenter_registered_once(self):
+        from erasus.core.registry import selector_registry
+
+        # Only "kcenter" should be registered, not "k_center"
+        assert "kcenter" in selector_registry.list()
+
+    def test_k_center_import_still_works(self):
+        from erasus.selectors.geometry_based.k_center import KCenterSelector
+        from erasus.selectors.geometry_based.kcenter import KCenterSelector as KC2
+
+        assert KCenterSelector is KC2
+
+
+# ======================================================================
+# Pre-commit config exists
+# ======================================================================
+
+
+class TestInfrastructure:
+    def test_precommit_config_exists(self):
+        from pathlib import Path
+
+        config = Path("/Users/avaya.aggarwal@zomato.com/erasus/.pre-commit-config.yaml")
+        assert config.exists()


### PR DESCRIPTION
## Summary

Resolves the critical and high-priority items from #9 (Comprehensive code review):

- **Silent selector fallbacks fixed** -- 4 selectors (`valuation_network`, `forgetting_events`, `data_shapley`, `glister`) now raise `SelectorError` with clear remediation instructions instead of silently falling back to random selection
- **`print()` replaced with `logging`** -- `submodular` and `voting` selectors now use `logger.warning()` instead of bare `print()`
- **Batch unpacking centralised** -- New `erasus/utils/batch.py` with `unpack_batch()` utility handling tuple, dict, and single-tensor formats
- **Duplicate selector removed** -- `k_center.py` no longer registers a duplicate "k_center" name; canonical is "kcenter" only
- **Pre-commit config added** -- `.pre-commit-config.yaml` with ruff, mypy, and standard hooks
- **mypy config added** -- `[tool.mypy]` section in `pyproject.toml`
- **Coverage threshold** -- `[tool.coverage]` config with `fail_under=50` baseline

## Test plan

- [x] 14 new tests covering all fixes (selector errors, batch unpacking, dedup, infra)
- [x] Full suite: 442 passed, 0 regressions (1 pre-existing matplotlib skip)
- [ ] Run `pre-commit run --all-files` after installing pre-commit hooks

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
