### PR TITLE
Add unlearning robustness and evaluation updates

### DIFF
--- a/erasus/benchmarks/__init__.py
+++ b/erasus/benchmarks/__init__.py
@@ -17,6 +17,7 @@ from erasus.benchmarks.lm_eval_integration import (
     LMEvalWrapper,
     LMEvalBenchmark,
     BenchmarkComparison,
+    PostUnlearningBenchmarkSuite,
 )
 from erasus.benchmarks.benchmark_runner import (
     BenchmarkRunner,
@@ -35,6 +36,7 @@ __all__ = [
     "LMEvalWrapper",
     "LMEvalBenchmark",
     "BenchmarkComparison",
+    "PostUnlearningBenchmarkSuite",
     "BenchmarkRunner",
     "BenchmarkResult",
     "HuggingFaceModelLoader",

--- a/erasus/benchmarks/lm_eval_integration.py
+++ b/erasus/benchmarks/lm_eval_integration.py
@@ -294,6 +294,39 @@ class LMEvalBenchmark:
         return all_results
 
 
+class PostUnlearningBenchmarkSuite:
+    """
+    Standard post-unlearning benchmark wrapper for common LLM tasks.
+
+    Provides a single entry point for evaluating utility preservation on
+    MMLU, GSM8K, TruthfulQA, HellaSwag, and ARC after unlearning.
+    """
+
+    DEFAULT_TASKS = ["mmlu", "gsm8k", "truthfulqa", "hellaswag", "arc"]
+
+    def __init__(
+        self,
+        model: nn.Module,
+        tokenizer: Any,
+        device: str = "cpu",
+    ) -> None:
+        self.benchmark = LMEvalBenchmark(model, tokenizer, device=device)
+
+    def run(
+        self,
+        tasks: Optional[List[str]] = None,
+        num_fewshot: int = 0,
+        limit: Optional[int] = None,
+    ) -> Dict[str, Dict[str, float]]:
+        """Run the default post-unlearning benchmark suite."""
+        selected_tasks = tasks or list(self.DEFAULT_TASKS)
+        return self.benchmark.run_benchmark_suite(
+            tasks=selected_tasks,
+            num_fewshot=num_fewshot,
+            limit=limit,
+        )
+
+
 class BenchmarkComparison:
     """
     Compare model performance before/after unlearning.

--- a/erasus/evaluation/benchmark_protocol.py
+++ b/erasus/evaluation/benchmark_protocol.py
@@ -38,6 +38,8 @@ import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
+from erasus.metrics.utility.rouge import ROUGEMetric
+
 
 # ======================================================================
 # Protocol definitions
@@ -214,6 +216,17 @@ class BenchmarkReport:
             lines.append(
                 f"{name:<30} {mr.mean:>8.4f} {ci_str:>20} {gold_str:>8} {gap_str:>8} {pass_str:>6}"
             )
+        capability_delta = self.metadata.get("capability_delta_report")
+        if capability_delta:
+            lines.extend([
+                "",
+                "Capability Delta Report:",
+            ])
+            for metric_name, delta in sorted(capability_delta.items()):
+                lines.append(
+                    f"  {metric_name}: pre={delta['pre']:.4f} post={delta['post']:.4f} "
+                    f"delta={delta['delta']:.4f}"
+                )
         return "\n".join(lines)
 
     # ------------------------------------------------------------------
@@ -457,6 +470,7 @@ class UnlearningBenchmark:
         forget_data: DataLoader,
         retain_data: DataLoader,
         gold_model: Optional[nn.Module] = None,
+        baseline_model: Optional[nn.Module] = None,
         **kwargs: Any,
     ) -> BenchmarkReport:
         """
@@ -513,6 +527,19 @@ class UnlearningBenchmark:
 
             results[spec.name] = mr
 
+        metadata = {
+            "protocol_description": PROTOCOLS[self.protocol]["description"],
+            "n_metrics": len(self._metrics),
+        }
+        if baseline_model is not None:
+            metadata["capability_delta_report"] = self._compute_capability_delta_report(
+                baseline_model=baseline_model,
+                unlearned_model=unlearned_model,
+                forget_data=forget_data,
+                retain_data=retain_data,
+                **kwargs,
+            )
+
         return BenchmarkReport(
             protocol=self.protocol,
             gold_standard=self.gold_standard,
@@ -520,11 +547,36 @@ class UnlearningBenchmark:
             confidence_level=self.confidence_level,
             metric_results=results,
             elapsed_time=time.time() - t0,
-            metadata={
-                "protocol_description": PROTOCOLS[self.protocol]["description"],
-                "n_metrics": len(self._metrics),
-            },
+            metadata=metadata,
         )
+
+    def _compute_capability_delta_report(
+        self,
+        baseline_model: nn.Module,
+        unlearned_model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: DataLoader,
+        **kwargs: Any,
+    ) -> Dict[str, Dict[str, float]]:
+        report: Dict[str, Dict[str, float]] = {}
+        for spec in self._metrics:
+            compute_fn = getattr(self._runner, spec.compute_fn, None)
+            if compute_fn is None:
+                continue
+            pre = compute_fn(
+                model=baseline_model,
+                forget_data=forget_data,
+                retain_data=retain_data,
+                **kwargs,
+            )
+            post = compute_fn(
+                model=unlearned_model,
+                forget_data=forget_data,
+                retain_data=retain_data,
+                **kwargs,
+            )
+            report[spec.name] = {"pre": float(pre), "post": float(post), "delta": float(post - pre)}
+        return report
 
 
 # ======================================================================
@@ -541,10 +593,12 @@ class _BenchmarkRunner:
         retain_data: DataLoader,
         **kwargs: Any,
     ) -> float:
-        """Compute forget quality: lower accuracy on forget set = better forgetting."""
+        """Compute forget quality using accuracy or ROUGE-L overlap."""
         model.eval()
         correct, total = 0, 0
         device = next(model.parameters()).device
+        rouge_l_scores: List[float] = []
+        tokenizer = kwargs.get("tokenizer")
 
         with torch.no_grad():
             for batch in forget_data:
@@ -554,10 +608,29 @@ class _BenchmarkRunner:
                 logits = outputs.logits if hasattr(outputs, "logits") else outputs
                 if labels is not None:
                     preds = logits.argmax(dim=-1)
-                    correct += (preds == labels).sum().item()
-                    total += labels.size(0)
+                    if labels.dim() > 1:
+                        for i in range(labels.size(0)):
+                            ref = self._decode_sequence(labels[i], tokenizer)
+                            hyp = self._decode_sequence(preds[i], tokenizer)
+                            rouge_l_scores.append(
+                                ROUGEMetric._rouge_l(ref.lower().split(), hyp.lower().split())
+                            )
+                    else:
+                        correct += (preds == labels).sum().item()
+                        total += labels.size(0)
 
+        if rouge_l_scores:
+            return float(sum(rouge_l_scores) / len(rouge_l_scores))
         return correct / max(total, 1)
+
+    @staticmethod
+    def _decode_sequence(values: torch.Tensor, tokenizer: Any = None) -> str:
+        valid = values[values.ne(-100)] if values.dim() > 0 else values
+        if tokenizer is not None:
+            return tokenizer.decode(valid, skip_special_tokens=True)
+        if valid.dim() == 0:
+            return str(int(valid.item()))
+        return " ".join(str(int(v)) for v in valid.detach().cpu().tolist())
 
     def _compute_model_utility(
         self,

--- a/erasus/evaluation/relearning.py
+++ b/erasus/evaluation/relearning.py
@@ -322,6 +322,8 @@ class LoRARelearningAttack:
         Learning rate (default 1e-3).
     recovery_threshold : float
         Maximum allowed accuracy recovery (default 0.15).
+    related_data_fraction : float
+        Fraction of retain data used as related-data fine-tuning signal.
     """
 
     def __init__(
@@ -330,11 +332,13 @@ class LoRARelearningAttack:
         epochs: int = 3,
         lr: float = 1e-3,
         recovery_threshold: float = 0.15,
+        related_data_fraction: float = 1.0,
     ):
         self.rank = rank
         self.epochs = epochs
         self.lr = lr
         self.recovery_threshold = recovery_threshold
+        self.related_data_fraction = related_data_fraction
 
     def run(
         self,
@@ -347,6 +351,7 @@ class LoRARelearningAttack:
 
         # Baseline
         pre_forget = _compute_metrics(model, forget_data, device)
+        pre_related = _compute_metrics(model, retain_data, device)
 
         # Create LoRA-augmented model
         lora_model = _LoRAWrapper(model, rank=self.rank).to(device)
@@ -363,10 +368,11 @@ class LoRARelearningAttack:
 
         optimizer = torch.optim.Adam(lora_params, lr=self.lr)
         criterion = nn.CrossEntropyLoss()
+        related_loader = _subset_loader(retain_data, self.related_data_fraction)
 
-        # Fine-tune LoRA on retain data
+        # Fine-tune LoRA on related retain-domain data
         for epoch in range(self.epochs):
-            for batch in retain_data:
+            for batch in related_loader:
                 if not isinstance(batch, (list, tuple)) or len(batch) < 2:
                     continue
                 inputs, targets = batch[0].to(device), batch[1].to(device)
@@ -380,7 +386,10 @@ class LoRARelearningAttack:
 
         # Measure post-LoRA metrics
         post_forget = _compute_metrics(lora_model, forget_data, device)
+        post_related = _compute_metrics(lora_model, retain_data, device)
         acc_recovery = post_forget["accuracy"] - pre_forget["accuracy"]
+        loss_recovery = pre_forget["loss"] - post_forget["loss"]
+        concept_revival = acc_recovery + max(loss_recovery, 0.0)
 
         # Count trainable parameters
         n_lora_params = sum(p.numel() for p in lora_params)
@@ -393,15 +402,20 @@ class LoRARelearningAttack:
             "lora_params": int(n_lora_params),
             "total_params": int(n_total_params),
             "lora_param_ratio": float(n_lora_params / max(n_total_params, 1)),
+            "related_data_fraction": float(self.related_data_fraction),
             "pre_forget_accuracy": float(pre_forget["accuracy"]),
             "post_forget_accuracy": float(post_forget["accuracy"]),
+            "pre_related_accuracy": float(pre_related["accuracy"]),
+            "post_related_accuracy": float(post_related["accuracy"]),
             "forget_accuracy_recovery": float(acc_recovery),
-            "passed": acc_recovery < self.recovery_threshold,
+            "forget_loss_recovery": float(loss_recovery),
+            "concept_revival": float(concept_revival),
+            "passed": concept_revival < self.recovery_threshold,
             "interpretation": (
-                f"LoRA (rank {self.rank}) recovered only {acc_recovery:.1%} accuracy (robust)"
-                if acc_recovery < self.recovery_threshold
-                else f"LoRA (rank {self.rank}, {n_lora_params} params) recovered "
-                     f"{acc_recovery:.1%} accuracy — unlearning is shallow"
+                f"LoRA (rank {self.rank}) produced only {concept_revival:.1%} concept revival (robust)"
+                if concept_revival < self.recovery_threshold
+                else f"LoRA (rank {self.rank}, {n_lora_params} params) revived forgotten behavior by "
+                     f"{concept_revival:.1%} after related-data fine-tuning"
             ),
         }
 
@@ -458,6 +472,22 @@ class _LoRAWrapper(nn.Module):
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
         return self.base_model(*args, **kwargs)
+
+
+def _subset_loader(loader: DataLoader, fraction: float) -> DataLoader:
+    """Create a deterministic prefix subset of a loader's dataset."""
+    fraction = min(max(fraction, 0.0), 1.0)
+    if fraction >= 1.0 or not hasattr(loader, "dataset"):
+        return loader
+
+    dataset = loader.dataset
+    subset_size = max(1, int(len(dataset) * fraction))
+    subset = torch.utils.data.Subset(dataset, list(range(subset_size)))
+    return DataLoader(
+        subset,
+        batch_size=loader.batch_size,
+        shuffle=False,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/erasus/metrics/__init__.py
+++ b/erasus/metrics/__init__.py
@@ -14,12 +14,18 @@ from erasus.metrics.retrieval_metrics import ZeroShotAccuracyMetric
 # New metric modules
 from erasus.metrics.metric_suite import MetricSuite
 from erasus.metrics.forgetting.mia import MIAMetric
-from erasus.metrics.forgetting.mia_variants import LiRAMetric, LabelOnlyMIAMetric
+from erasus.metrics.forgetting.mia_variants import (
+    LabelOnlyMIAMetric,
+    LiRAMetric,
+    MinKProbMetric,
+    ZLibMIAMetric,
+)
 from erasus.metrics.forgetting.confidence import ConfidenceMetric
 from erasus.metrics.forgetting.feature_distance import FeatureDistanceMetric
 from erasus.metrics.efficiency.time_complexity import TimeComplexityMetric
 from erasus.metrics.efficiency.memory_usage import MemoryUsageMetric
 from erasus.metrics.privacy.differential_privacy import DPEvaluationMetric
+from erasus.metrics.privacy.privacy_leakage import PrivacyLeakageMetric
 
 # Sprint A metrics
 from erasus.metrics.forgetting.activation_analysis import ActivationAnalysis
@@ -62,11 +68,14 @@ for name, cls in [
     ("mia_full", MIAMetric),
     ("lira", LiRAMetric),
     ("label_only_mia", LabelOnlyMIAMetric),
+    ("zlib_mia", ZLibMIAMetric),
+    ("mink", MinKProbMetric),
     ("confidence", ConfidenceMetric),
     ("feature_distance", FeatureDistanceMetric),
     ("time_complexity", TimeComplexityMetric),
     ("memory_usage", MemoryUsageMetric),
     ("dp_evaluation", DPEvaluationMetric),
+    ("privacy_leakage", PrivacyLeakageMetric),
     ("mia_suite", MIASuite),
     ("extraction_strength", ExtractionStrengthMetric),
     ("exact_memorization", ExactMemorizationMetric),
@@ -89,11 +98,14 @@ __all__ = [
     "MIAMetric",
     "LiRAMetric",
     "LabelOnlyMIAMetric",
+    "ZLibMIAMetric",
+    "MinKProbMetric",
     "ConfidenceMetric",
     "FeatureDistanceMetric",
     "TimeComplexityMetric",
     "MemoryUsageMetric",
     "DPEvaluationMetric",
+    "PrivacyLeakageMetric",
     # Sprint A
     "ActivationAnalysis",
     "BackdoorActivation",

--- a/erasus/metrics/forgetting/exact_memorization.py
+++ b/erasus/metrics/forgetting/exact_memorization.py
@@ -1,0 +1,164 @@
+"""
+erasus.metrics.forgetting.exact_memorization — Exact match memorization.
+
+Implements exact string/tensor-match detection for extractable forget-set
+content. The metric supports both generative outputs and classifier-style
+predictions, falling back to exact label matches when generation is not
+available.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from erasus.core.base_metric import BaseMetric
+
+
+class ExactMemorizationMetric(BaseMetric):
+    """
+    Exact memorization via exact string/tensor match detection.
+
+    Parameters
+    ----------
+    confidence_threshold : float
+        Confidence threshold used for classifier-style fallback.
+    prefix_length : int
+        Number of tokens/elements to keep as the prompt prefix when a
+        sequence target is available.
+    max_new_tokens : int
+        Maximum number of tokens to generate beyond the prompt prefix.
+    """
+
+    name = "exact_memorization"
+
+    def __init__(
+        self,
+        confidence_threshold: float = 0.8,
+        prefix_length: int = 4,
+        max_new_tokens: int = 32,
+    ) -> None:
+        self.confidence_threshold = confidence_threshold
+        self.prefix_length = prefix_length
+        self.max_new_tokens = max_new_tokens
+
+    def compute(
+        self,
+        model: nn.Module,
+        forget_data: Optional[DataLoader] = None,
+        retain_data: Optional[DataLoader] = None,
+        **kwargs: Any,
+    ) -> Dict[str, float]:
+        if forget_data is None:
+            return {"exact_memorization_forget": 0.0}
+
+        device = next(model.parameters()).device
+        model.eval()
+
+        forget_rate, forget_scores = self._compute_exact_rate(model, forget_data, device)
+        results: Dict[str, float] = {
+            "exact_memorization_forget": float(forget_rate),
+            "exact_memorization_forget_mean_conf": float(np.mean(forget_scores))
+            if forget_scores
+            else 0.0,
+        }
+
+        if retain_data is not None:
+            retain_rate, retain_scores = self._compute_exact_rate(model, retain_data, device)
+            results["exact_memorization_retain"] = float(retain_rate)
+            results["exact_memorization_retain_mean_conf"] = float(np.mean(retain_scores))
+            if not retain_scores:
+                results["exact_memorization_retain_mean_conf"] = 0.0
+            results["exact_memorization_gap"] = float(retain_rate - forget_rate)
+
+        return results
+
+    def _compute_exact_rate(
+        self,
+        model: nn.Module,
+        loader: DataLoader,
+        device: torch.device,
+    ) -> Tuple[float, List[float]]:
+        exact_matches = 0
+        total = 0
+        confidences: List[float] = []
+
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+
+                if self._can_generate(model, targets):
+                    match_count, batch_scores = self._exact_match_generation(
+                        model=model,
+                        inputs=inputs,
+                        targets=targets,
+                        device=device,
+                    )
+                    exact_matches += match_count
+                    total += len(batch_scores)
+                    confidences.extend(batch_scores)
+                    continue
+
+                outputs = model(inputs)
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs
+                probs = torch.softmax(logits, dim=-1)
+                preds = logits.argmax(dim=-1)
+
+                for i in range(targets.size(0)):
+                    if targets.dim() == 1:
+                        conf = probs[i, targets[i]].item()
+                        matched = preds[i].item() == targets[i].item()
+                    else:
+                        matched = torch.equal(preds[i], targets[i])
+                        conf = self._sequence_confidence(probs[i], targets[i])
+
+                    confidences.append(conf)
+                    if matched and conf >= self.confidence_threshold:
+                        exact_matches += 1
+                    total += 1
+
+        return exact_matches / max(total, 1), confidences
+
+    def _exact_match_generation(
+        self,
+        model: nn.Module,
+        inputs: torch.Tensor,
+        targets: torch.Tensor,
+        device: torch.device,
+    ) -> Tuple[int, List[float]]:
+        """Measure exact sequence reconstruction from prefix prompting."""
+        generated = model.generate(inputs, max_new_tokens=self.max_new_tokens)
+        matches = 0
+        scores: List[float] = []
+
+        for pred_seq, target_seq in zip(generated, targets):
+            pred_valid = pred_seq[pred_seq.ne(-100)] if pred_seq.ndim > 0 else pred_seq
+            target_valid = target_seq[target_seq.ne(-100)] if target_seq.ndim > 0 else target_seq
+            matched = torch.equal(pred_valid.to(device), target_valid.to(device))
+            score = 1.0 if matched else 0.0
+            scores.append(score)
+            if matched:
+                matches += 1
+
+        return matches, scores
+
+    @staticmethod
+    def _can_generate(model: nn.Module, targets: torch.Tensor) -> bool:
+        return hasattr(model, "generate") and targets.dim() > 1
+
+    @staticmethod
+    def _sequence_confidence(probs: torch.Tensor, targets: torch.Tensor) -> float:
+        safe_targets = targets.clamp_min(0)
+        gathered = probs.gather(-1, safe_targets.unsqueeze(-1)).squeeze(-1)
+        valid = targets.ne(-100) if targets.dim() > 0 else torch.tensor(True, device=targets.device)
+        valid_scores = gathered[valid]
+        if valid_scores.numel() == 0:
+            return 0.0
+        return float(valid_scores.mean().item())

--- a/erasus/metrics/forgetting/extraction_strength.py
+++ b/erasus/metrics/forgetting/extraction_strength.py
@@ -1,0 +1,121 @@
+"""
+erasus.metrics.forgetting.extraction_strength — Prefix-prompt extraction.
+
+Measures how much forget-set content can be extracted by prompting the
+model with prefixes from the forget data and evaluating whether the
+continuation is recoverable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from erasus.core.base_metric import BaseMetric
+
+
+class ExtractionStrengthMetric(BaseMetric):
+    """
+    Prefix-prompt extraction strength.
+
+    For sequence targets, prompt with a prefix and measure exact
+    continuation recovery. For classifier-style tasks, fall back to the
+    top-k extraction definition.
+    """
+
+    name = "extraction_strength"
+
+    def __init__(self, top_k: int = 1, prefix_length: int = 4, max_new_tokens: int = 32):
+        self.top_k = top_k
+        self.prefix_length = prefix_length
+        self.max_new_tokens = max_new_tokens
+
+    def compute(
+        self,
+        model: nn.Module,
+        forget_data: Optional[DataLoader] = None,
+        retain_data: Optional[DataLoader] = None,
+        **kwargs: Any,
+    ) -> Dict[str, float]:
+        if forget_data is None:
+            return {"extraction_strength": 0.0}
+
+        device = next(model.parameters()).device
+        model.eval()
+
+        forget_es = self._compute_extraction(model, forget_data, device)
+        results: Dict[str, float] = {"extraction_strength_forget": float(forget_es)}
+
+        if retain_data is not None:
+            retain_es = self._compute_extraction(model, retain_data, device)
+            results["extraction_strength_retain"] = float(retain_es)
+            results["extraction_strength_gap"] = float(forget_es - retain_es)
+            random_baseline = self.top_k / max(self._infer_num_classes(model, forget_data, device), 1)
+            results["extraction_resistance"] = min(
+                1.0,
+                max(
+                    0.0,
+                    1.0 - (forget_es - random_baseline) / max(1.0 - random_baseline, 1e-8),
+                ),
+            )
+
+        return results
+
+    def _compute_extraction(
+        self,
+        model: nn.Module,
+        loader: DataLoader,
+        device: torch.device,
+    ) -> float:
+        extracted = 0
+        total = 0
+
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+
+                if hasattr(model, "generate") and targets.dim() > 1:
+                    generated = model.generate(inputs, max_new_tokens=self.max_new_tokens)
+                    for pred_seq, target_seq in zip(generated, targets):
+                        target_valid = target_seq[target_seq.ne(-100)]
+                        prefix_len = min(self.prefix_length, target_valid.numel())
+                        suffix = target_valid[prefix_len:]
+                        pred_valid = pred_seq[pred_seq.ne(-100)]
+                        pred_suffix = pred_valid[prefix_len : prefix_len + suffix.numel()]
+                        if suffix.numel() == 0 or torch.equal(pred_suffix, suffix):
+                            extracted += 1
+                        total += 1
+                    continue
+
+                outputs = model(inputs)
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs
+                _, top_k_preds = logits.topk(min(self.top_k, logits.size(-1)), dim=-1)
+
+                for i in range(targets.size(0)):
+                    if targets[i] in top_k_preds[i]:
+                        extracted += 1
+                    total += 1
+
+        return extracted / max(total, 1)
+
+    @staticmethod
+    def _infer_num_classes(
+        model: nn.Module,
+        loader: DataLoader,
+        device: torch.device,
+    ) -> int:
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)):
+                    continue
+                inputs = batch[0].to(device)
+                outputs = model(inputs)
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs
+                return logits.size(-1)
+        return 1

--- a/erasus/metrics/forgetting/memorization.py
+++ b/erasus/metrics/forgetting/memorization.py
@@ -2,21 +2,14 @@
 erasus.metrics.forgetting.memorization — Memorization detection metrics.
 
 Implements:
-- Extraction Strength (ES): How much of the forget data can be extracted
-  via generation probing.
-- Exact Memorization (EM): Exact string/tensor match of forget data in
-  model output.
-- Verbatim Memorization: Longest common subsequence ratio between model
-  output and forget data.
-- KnowMem: Knowledge memorization score based on generation overlap.
-
-These metrics go beyond MIA (which tests membership classification) to
-measure whether the model can *reproduce* forget-set content.
+- Extraction Strength (ES): extractable forget data via prefix probing
+- Exact Memorization (EM): exact string/tensor match detection
+- Verbatim Memorization: longest-common-substring and n-gram overlap detection
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 import torch
@@ -24,211 +17,19 @@ import torch.nn as nn
 from torch.utils.data import DataLoader
 
 from erasus.core.base_metric import BaseMetric
-
-
-class ExtractionStrengthMetric(BaseMetric):
-    """
-    Extraction Strength (ES).
-
-    Measures how much information about forget-set samples can be
-    extracted from the model by querying it.  For classifiers, this is
-    the fraction of forget samples where the model's top-k predictions
-    contain the true label.  For generative models, this would measure
-    output overlap (requires a generate method).
-
-    After successful unlearning, ES should be ≈ random-chance level.
-
-    Parameters
-    ----------
-    top_k : int
-        Number of top predictions to consider (default 1).
-    """
-
-    name = "extraction_strength"
-
-    def __init__(self, top_k: int = 1):
-        self.top_k = top_k
-
-    def compute(
-        self,
-        model: nn.Module,
-        forget_data: Optional[DataLoader] = None,
-        retain_data: Optional[DataLoader] = None,
-        **kwargs: Any,
-    ) -> Dict[str, float]:
-        if forget_data is None:
-            return {"extraction_strength": 0.0}
-
-        device = next(model.parameters()).device
-        model.eval()
-
-        forget_es = self._compute_extraction(model, forget_data, device)
-        results: Dict[str, float] = {
-            "extraction_strength_forget": float(forget_es),
-        }
-
-        if retain_data is not None:
-            retain_es = self._compute_extraction(model, retain_data, device)
-            results["extraction_strength_retain"] = float(retain_es)
-            # Relative ES: how much more extractable is forget vs retain
-            # After good unlearning, this should be ≤ 0
-            results["extraction_strength_gap"] = float(forget_es - retain_es)
-            # Normalised score: 1.0 = perfect (forget ES = 0), 0.0 = no unlearning
-            random_baseline = self.top_k / max(self._infer_num_classes(model, forget_data, device), 1)
-            results["extraction_resistance"] = min(1.0, max(
-                0.0, 1.0 - (forget_es - random_baseline) / max(1.0 - random_baseline, 1e-8)
-            ))
-
-        return results
-
-    def _compute_extraction(
-        self, model: nn.Module, loader: DataLoader, device: torch.device,
-    ) -> float:
-        """Fraction of samples where true label is in top-k predictions."""
-        extracted = 0
-        total = 0
-
-        with torch.no_grad():
-            for batch in loader:
-                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
-                    continue
-                inputs, targets = batch[0].to(device), batch[1].to(device)
-                outputs = model(inputs)
-                if hasattr(outputs, "logits"):
-                    outputs = outputs.logits
-
-                _, top_k_preds = outputs.topk(min(self.top_k, outputs.size(-1)), dim=-1)
-                for i in range(targets.size(0)):
-                    if targets[i] in top_k_preds[i]:
-                        extracted += 1
-                    total += 1
-
-        return extracted / max(total, 1)
-
-    @staticmethod
-    def _infer_num_classes(
-        model: nn.Module, loader: DataLoader, device: torch.device,
-    ) -> int:
-        """Infer the number of classes from the model output."""
-        with torch.no_grad():
-            for batch in loader:
-                if not isinstance(batch, (list, tuple)):
-                    continue
-                inputs = batch[0].to(device)
-                outputs = model(inputs)
-                if hasattr(outputs, "logits"):
-                    outputs = outputs.logits
-                return outputs.size(-1)
-        return 1
-
-
-class ExactMemorizationMetric(BaseMetric):
-    """
-    Exact Memorization (EM).
-
-    For classifiers: measures the fraction of forget-set samples that
-    the model classifies with the *exact* same confidence ranking as a
-    model that was trained on them (i.e., correct label has highest
-    probability AND confidence exceeds a threshold).
-
-    This is stricter than accuracy — it requires the model to be
-    *confidently correct*, which is the signature of memorization.
-
-    Parameters
-    ----------
-    confidence_threshold : float
-        Minimum softmax probability for the correct class to count as
-        "exactly memorised" (default 0.8).
-    """
-
-    name = "exact_memorization"
-
-    def __init__(self, confidence_threshold: float = 0.8):
-        self.confidence_threshold = confidence_threshold
-
-    def compute(
-        self,
-        model: nn.Module,
-        forget_data: Optional[DataLoader] = None,
-        retain_data: Optional[DataLoader] = None,
-        **kwargs: Any,
-    ) -> Dict[str, float]:
-        if forget_data is None:
-            return {"exact_memorization_forget": 0.0}
-
-        device = next(model.parameters()).device
-        model.eval()
-
-        forget_em, forget_confs = self._compute_em(model, forget_data, device)
-        results: Dict[str, float] = {
-            "exact_memorization_forget": float(forget_em),
-            "exact_memorization_forget_mean_conf": float(np.mean(forget_confs)) if forget_confs else 0.0,
-        }
-
-        if retain_data is not None:
-            retain_em, retain_confs = self._compute_em(model, retain_data, device)
-            results["exact_memorization_retain"] = float(retain_em)
-            results["exact_memorization_retain_mean_conf"] = float(np.mean(retain_confs)) if retain_confs else 0.0
-            results["exact_memorization_gap"] = float(retain_em - forget_em)
-
-        return results
-
-    def _compute_em(
-        self, model: nn.Module, loader: DataLoader, device: torch.device,
-    ) -> Tuple[float, List[float]]:
-        """Fraction of samples that are confidently correctly classified."""
-        memorised = 0
-        total = 0
-        confidences: List[float] = []
-
-        with torch.no_grad():
-            for batch in loader:
-                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
-                    continue
-                inputs, targets = batch[0].to(device), batch[1].to(device)
-                outputs = model(inputs)
-                if hasattr(outputs, "logits"):
-                    outputs = outputs.logits
-
-                probs = torch.softmax(outputs, dim=-1)
-
-                for i in range(targets.size(0)):
-                    target_prob = probs[i, targets[i]].item()
-                    confidences.append(target_prob)
-                    pred = outputs[i].argmax().item()
-                    if pred == targets[i].item() and target_prob >= self.confidence_threshold:
-                        memorised += 1
-                    total += 1
-
-        return memorised / max(total, 1), confidences
+from erasus.metrics.forgetting.exact_memorization import ExactMemorizationMetric
+from erasus.metrics.forgetting.extraction_strength import ExtractionStrengthMetric
 
 
 class VerbatimMemorizationMetric(BaseMetric):
     """
-    Verbatim Memorization.
-
-    Measures how closely the model's output distribution matches the
-    training signal for forget-set samples.  Uses the KL divergence
-    between the model's softmax distribution and the one-hot target
-    as a proxy for verbatim memorization.
-
-    Lower KL (closer to zero) = more memorized = worse unlearning.
-    Higher KL = more forgotten = better unlearning.
-
-    Also computes the "memorization score" as the fraction of samples
-    where the model's prediction entropy is below a threshold.
+    Verbatim memorization via overlap between generated/predicted outputs
+    and forget targets.
     """
 
     name = "verbatim_memorization"
 
     def __init__(self, entropy_threshold: Optional[float] = None):
-        """
-        Parameters
-        ----------
-        entropy_threshold : float, optional
-            Maximum entropy to consider a sample "memorised".
-            If None, uses ``0.5 * log(num_classes)`` as default.
-        """
         self.entropy_threshold = entropy_threshold
 
     def compute(
@@ -263,10 +64,8 @@ class VerbatimMemorizationMetric(BaseMetric):
     def _analyse(
         self, model: nn.Module, loader: DataLoader, device: torch.device,
     ) -> Tuple[np.ndarray, np.ndarray, float]:
-        """Compute per-sample KL, entropy, and memorization rate."""
-        kl_divs: list = []
-        entropies: list = []
-        num_classes = None
+        overlap_scores: list[float] = []
+        substring_scores: list[float] = []
         memorised = 0
         total = 0
 
@@ -276,32 +75,62 @@ class VerbatimMemorizationMetric(BaseMetric):
                     continue
                 inputs, targets = batch[0].to(device), batch[1].to(device)
                 outputs = model(inputs)
-                if hasattr(outputs, "logits"):
-                    outputs = outputs.logits
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs
+                preds = logits.argmax(dim=-1)
 
-                if num_classes is None:
-                    num_classes = outputs.size(-1)
-
-                log_probs = torch.log_softmax(outputs, dim=-1)
-                probs = torch.softmax(outputs, dim=-1)
-
-                # Per-sample entropy
-                ent = -(probs * log_probs).sum(dim=-1)
-                entropies.extend(ent.cpu().tolist())
-
-                # Per-sample KL divergence from one-hot target
-                # KL(one_hot || model) = -log(p_target)
                 for i in range(targets.size(0)):
-                    kl = -log_probs[i, targets[i]].item()
-                    kl_divs.append(kl)
+                    target_tokens = self._token_list(targets[i])
+                    pred_tokens = self._token_list(preds[i])
 
-                    # Check memorization
-                    thresh = self.entropy_threshold
-                    if thresh is None and num_classes is not None:
-                        thresh = 0.5 * np.log(num_classes)
-                    if thresh is not None and ent[i].item() < thresh:
+                    ngram_overlap = self._ngram_overlap(target_tokens, pred_tokens, n=3)
+                    longest_substring = self._longest_common_substring_ratio(
+                        target_tokens, pred_tokens
+                    )
+                    overlap_scores.append(1.0 - ngram_overlap)
+                    substring_scores.append(1.0 - longest_substring)
+
+                    memorization_signal = max(ngram_overlap, longest_substring)
+                    thresh = self.entropy_threshold if self.entropy_threshold is not None else 0.5
+                    if memorization_signal >= thresh:
                         memorised += 1
                     total += 1
 
         mem_rate = memorised / max(total, 1)
-        return np.array(kl_divs), np.array(entropies), mem_rate
+        return np.array(overlap_scores), np.array(substring_scores), mem_rate
+
+    @staticmethod
+    def _token_list(value: torch.Tensor) -> list[str]:
+        if value.dim() == 0:
+            return [str(int(value.item()))]
+        valid = value[value.ne(-100)] if value.dtype in (torch.int32, torch.int64) else value
+        return [str(int(v)) for v in valid.detach().cpu().flatten().tolist()]
+
+    @staticmethod
+    def _ngram_overlap(reference: list[str], hypothesis: list[str], n: int = 3) -> float:
+        if len(reference) < n or len(hypothesis) < n:
+            return float(reference == hypothesis) if reference or hypothesis else 0.0
+        ref = {tuple(reference[i : i + n]) for i in range(len(reference) - n + 1)}
+        hyp = {tuple(hypothesis[i : i + n]) for i in range(len(hypothesis) - n + 1)}
+        if not ref:
+            return 0.0
+        return len(ref & hyp) / len(ref)
+
+    @staticmethod
+    def _longest_common_substring_ratio(reference: list[str], hypothesis: list[str]) -> float:
+        if not reference or not hypothesis:
+            return 0.0
+        dp = [[0] * (len(hypothesis) + 1) for _ in range(len(reference) + 1)]
+        best = 0
+        for i in range(1, len(reference) + 1):
+            for j in range(1, len(hypothesis) + 1):
+                if reference[i - 1] == hypothesis[j - 1]:
+                    dp[i][j] = dp[i - 1][j - 1] + 1
+                    best = max(best, dp[i][j])
+        return best / max(len(reference), 1)
+
+
+__all__ = [
+    "ExtractionStrengthMetric",
+    "ExactMemorizationMetric",
+    "VerbatimMemorizationMetric",
+]

--- a/erasus/metrics/forgetting/mia_variants.py
+++ b/erasus/metrics/forgetting/mia_variants.py
@@ -4,15 +4,19 @@ erasus.metrics.forgetting.mia_variants — Advanced MIA variants.
 Includes:
 - LiRA (Likelihood Ratio Attack) — Carlini et al., 2022
 - Label-Only MIA — Choquette-Choo et al., 2021
+- ZLib MIA — loss normalised by zlib compression ratio
+- Min-K% Prob — average log-probability of the K% lowest-probability tokens
 """
 
 from __future__ import annotations
 
+import zlib
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
 from erasus.core.base_metric import BaseMetric
@@ -196,3 +200,149 @@ class LabelOnlyMIAMetric(BaseMetric):
                 correct += (preds == targets).sum().item()
                 total += targets.size(0)
         return correct / max(total, 1)
+
+
+class ZLibMIAMetric(BaseMetric):
+    """
+    ZLib-normalised membership inference attack.
+
+    Uses per-sample loss divided by compressed input length to reduce the
+    bias toward naturally low-entropy samples.
+    """
+
+    name = "zlib_mia"
+
+    def compute(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: DataLoader,
+        **kwargs: Any,
+    ) -> Dict[str, float]:
+        device = next(model.parameters()).device
+        model.eval()
+
+        forget_scores = self._collect_scores(model, forget_data, device)
+        retain_scores = self._collect_scores(model, retain_data, device)
+        labels = np.concatenate([np.ones(len(forget_scores)), np.zeros(len(retain_scores))])
+        scores = np.concatenate([forget_scores, retain_scores])
+
+        return {
+            "zlib_mia_forget_mean": float(np.mean(forget_scores)) if len(forget_scores) else 0.0,
+            "zlib_mia_retain_mean": float(np.mean(retain_scores)) if len(retain_scores) else 0.0,
+            "zlib_mia_auc": float(LiRAMetric._simple_auc(labels, scores)),
+        }
+
+    def _collect_scores(
+        self,
+        model: nn.Module,
+        loader: DataLoader,
+        device: torch.device,
+    ) -> np.ndarray:
+        criterion = nn.CrossEntropyLoss(reduction="none")
+        collected: List[np.ndarray] = []
+
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                outputs = model(inputs)
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs
+                losses = criterion(logits, targets).cpu().numpy()
+
+                z_lengths: List[float] = []
+                raw_inputs = batch[0].detach().cpu()
+                for sample in raw_inputs:
+                    compressed = len(zlib.compress(sample.numpy().tobytes()))
+                    z_lengths.append(float(max(compressed, 1)))
+
+                z_arr = np.array(z_lengths, dtype=np.float64)
+                collected.append(-(losses / z_arr))
+
+        return np.concatenate(collected) if collected else np.array([])
+
+
+class MinKProbMetric(BaseMetric):
+    """
+    Min-K% probability membership inference metric.
+
+    For each sample, compute the log-probabilities assigned to the
+    target tokens/labels, sort them, and average the lowest ``k%``.
+    Higher values indicate stronger memorisation because even the
+    hardest tokens receive relatively high probability.
+    """
+
+    name = "mink"
+
+    def __init__(self, k_percent: float = 20.0) -> None:
+        if not 0 < k_percent <= 100:
+            raise ValueError("k_percent must be in the interval (0, 100].")
+        self.k_percent = k_percent
+
+    def compute(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: DataLoader,
+        **kwargs: Any,
+    ) -> Dict[str, float]:
+        device = next(model.parameters()).device
+        model.eval()
+
+        forget_scores = self._collect_mink_scores(model, forget_data, device)
+        retain_scores = self._collect_mink_scores(model, retain_data, device)
+
+        labels = np.concatenate([np.ones(len(forget_scores)), np.zeros(len(retain_scores))])
+        scores = np.concatenate([forget_scores, retain_scores])
+
+        return {
+            "mink_forget_mean": float(np.mean(forget_scores)) if len(forget_scores) else 0.0,
+            "mink_retain_mean": float(np.mean(retain_scores)) if len(retain_scores) else 0.0,
+            "mink_auc": float(LiRAMetric._simple_auc(labels, scores)),
+        }
+
+    def _collect_mink_scores(
+        self,
+        model: nn.Module,
+        loader: DataLoader,
+        device: torch.device,
+    ) -> np.ndarray:
+        scores: List[float] = []
+
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                outputs = model(inputs)
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs
+                log_probs = F.log_softmax(logits, dim=-1)
+
+                if logits.dim() == 2 and targets.dim() == 1:
+                    token_log_probs = log_probs.gather(1, targets.unsqueeze(1)).squeeze(1)
+                    token_log_probs = token_log_probs.unsqueeze(1)
+                    valid_mask = torch.ones_like(token_log_probs, dtype=torch.bool)
+                elif logits.dim() >= 3 and targets.dim() == logits.dim() - 1:
+                    safe_targets = targets.clamp_min(0)
+                    token_log_probs = log_probs.gather(
+                        -1, safe_targets.unsqueeze(-1)
+                    ).squeeze(-1)
+                    valid_mask = targets.ne(-100)
+                else:
+                    token_log_probs = log_probs.max(dim=-1).values
+                    if token_log_probs.dim() == 1:
+                        token_log_probs = token_log_probs.unsqueeze(1)
+                    valid_mask = torch.ones_like(token_log_probs, dtype=torch.bool)
+
+                for sample_log_probs, sample_mask in zip(token_log_probs, valid_mask):
+                    valid_values = sample_log_probs[sample_mask]
+                    if valid_values.numel() == 0:
+                        continue
+                    k = max(1, int(np.ceil(valid_values.numel() * (self.k_percent / 100.0))))
+                    lowest_values, _ = torch.topk(valid_values, k=k, largest=False)
+                    scores.append(float(lowest_values.mean().item()))
+
+        return np.array(scores, dtype=np.float64)

--- a/erasus/metrics/privacy/__init__.py
+++ b/erasus/metrics/privacy/__init__.py
@@ -1,3 +1,7 @@
 """
 erasus.metrics.privacy — Privacy-related evaluation metrics.
 """
+
+from erasus.metrics.privacy.privacy_leakage import PrivacyLeakageMetric
+
+__all__ = ["PrivacyLeakageMetric"]

--- a/erasus/metrics/privacy/privacy_leakage.py
+++ b/erasus/metrics/privacy/privacy_leakage.py
@@ -1,0 +1,64 @@
+"""
+erasus.metrics.privacy.privacy_leakage — MUSE-style privacy leakage score.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+
+from erasus.core.base_metric import BaseMetric
+
+
+class PrivacyLeakageMetric(BaseMetric):
+    """
+    Privacy leakage score based on the forget/retain loss gap.
+
+    Lower forget loss relative to retain loss indicates higher leakage.
+    """
+
+    name = "privacy_leakage"
+
+    def compute(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: DataLoader,
+        **kwargs: Any,
+    ) -> Dict[str, float]:
+        device = next(model.parameters()).device
+        model.eval()
+
+        forget_loss = self._average_loss(model, forget_data, device)
+        retain_loss = self._average_loss(model, retain_data, device)
+
+        leakage = max(0.0, 1.0 - (forget_loss / (retain_loss + 1e-8))) if retain_loss > 0 else 0.0
+        return {
+            "privacy_leakage": float(leakage),
+            "privacy_forget_loss": float(forget_loss),
+            "privacy_retain_loss": float(retain_loss),
+        }
+
+    @staticmethod
+    def _average_loss(
+        model: nn.Module,
+        loader: DataLoader,
+        device: torch.device,
+    ) -> float:
+        total_loss = 0.0
+        total = 0
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, labels = batch[0].to(device), batch[1].to(device)
+                outputs = model(inputs)
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs
+                loss = F.cross_entropy(logits, labels, reduction="sum")
+                total_loss += float(loss.item())
+                total += labels.size(0)
+        return total_loss / max(total, 1)

--- a/erasus/strategies/__init__.py
+++ b/erasus/strategies/__init__.py
@@ -11,6 +11,7 @@ from erasus.strategies.gradient_methods.scrub import SCRUBStrategy
 from erasus.strategies.gradient_methods.fisher_forgetting import FisherForgettingStrategy
 from erasus.strategies.gradient_methods.negative_gradient import NegativeGradientStrategy
 from erasus.strategies.gradient_methods.weighted_gradient_ascent import WGAStrategy
+from erasus.strategies.gradient_methods.weighted_gradient_ascent import FPGAStrategy
 
 # Parameter methods
 from erasus.strategies.parameter_methods.lora_unlearning import LoRAUnlearningStrategy
@@ -84,6 +85,7 @@ __all__ = [
     "FisherForgettingStrategy",
     "NegativeGradientStrategy",
     "WGAStrategy",
+    "FPGAStrategy",
     "SaliencyUnlearningStrategy",
     "LoRAUnlearningStrategy",
     "EfficientLoRAStrategy",

--- a/erasus/strategies/diffusion_specific/meta_unlearning.py
+++ b/erasus/strategies/diffusion_specific/meta_unlearning.py
@@ -3,18 +3,9 @@ Meta-Unlearning on Diffusion Models — Robust Concept Erasure.
 
 Paper: "Meta-Unlearning for Stable Concept Erasure" (Gao et al., ICCV 2025)
 
-Key insight: CVPR 2025 research showed that ALL existing diffusion concept
-erasure methods (SalUn, ESD, EDiff, CA, MACE, SPM, SA, Receler, UCE) fail
-under downstream fine-tuning — erased concepts easily revive.
-
-Meta-unlearning uses meta-learning to make concept erasure robust. Instead of
-directly erasing the concept, the model learns to resist concept relearning even
-when fine-tuned on related data. This is the first defence against relearning
-attacks on diffusion models.
-
-Loss: L = L_meta_forget + λ · L_meta_retain
-where L_meta_forget is the meta-loss on the forget task,
-and L_meta_retain ensures retained concepts stay learnable.
+This strategy simulates post-unlearning relearning in an inner loop,
+then updates the original model to make that relearning less effective
+while preserving retain-set utility.
 """
 
 from __future__ import annotations
@@ -34,24 +25,22 @@ from erasus.core.registry import strategy_registry
 @strategy_registry.register("meta_unlearning")
 class MetaUnlearningStrategy(BaseStrategy):
     """
-    Meta-Unlearning: Robust concept erasure for diffusion models.
-
-    Uses meta-learning to protect against concept relearning via downstream
-    fine-tuning. The model learns to resist relearning instead of just
-    erasing the concept, making unlearning more stable.
+    Meta-learning-based robust concept erasure.
 
     Parameters
     ----------
     inner_lr : float
-        Learning rate for inner (within-batch) meta-loop (default 1e-4).
+        Learning rate for the simulated relearning loop.
     outer_lr : float
-        Learning rate for outer (across-batch) meta-loop (default 1e-5).
+        Learning rate for the outer anti-relearning update.
     num_inner_steps : int
-        Number of inner gradient steps per outer step (default 3).
+        Number of relearning simulation steps per forget batch.
     forget_weight : float
-        Weight of meta-forget loss (default 1.0).
+        Weight of the anti-relearning forget objective.
     retain_weight : float
-        Weight of meta-retain loss (default 1.0).
+        Weight of the retain-preservation objective.
+    adaptation_penalty : float
+        Weight of the parameter-drift penalty against the relearned clone.
     """
 
     def __init__(
@@ -61,6 +50,7 @@ class MetaUnlearningStrategy(BaseStrategy):
         num_inner_steps: int = 3,
         forget_weight: float = 1.0,
         retain_weight: float = 1.0,
+        adaptation_penalty: float = 0.1,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -69,6 +59,7 @@ class MetaUnlearningStrategy(BaseStrategy):
         self.num_inner_steps = num_inner_steps
         self.forget_weight = forget_weight
         self.retain_weight = retain_weight
+        self.adaptation_penalty = adaptation_penalty
 
     def unlearn(
         self,
@@ -79,70 +70,87 @@ class MetaUnlearningStrategy(BaseStrategy):
         **kwargs: Any,
     ) -> Tuple[nn.Module, List[float], List[float]]:
         device = next(model.parameters()).device
-
         model.train()
-        optimizer = torch.optim.Adam(model.parameters(), lr=self.outer_lr)
 
+        optimizer = torch.optim.Adam(model.parameters(), lr=self.outer_lr)
         forget_losses: List[float] = []
         retain_losses: List[float] = []
 
-        for epoch in range(epochs):
+        for _ in range(epochs):
             epoch_forget = 0.0
             epoch_retain = 0.0
             n_forget = 0
             n_retain = 0
 
-            # --- Meta-learning loop on forget data ---
-            # The idea: train the model such that it's hard to adapt to forget data.
-            # This is done by maximizing entropy on forget data while resisting changes.
             for forget_batch in forget_loader:
+                if not isinstance(forget_batch, (list, tuple)) or len(forget_batch) < 2:
+                    continue
+
                 forget_inputs = forget_batch[0].to(device)
+                forget_labels = forget_batch[1].to(device)
 
-                # Compute model output
-                out = model(forget_inputs)
-                logits = out.logits if hasattr(out, "logits") else out
+                adapted_model = copy.deepcopy(model).to(device)
+                adapted_model.train()
+                inner_optimizer = torch.optim.SGD(adapted_model.parameters(), lr=self.inner_lr)
 
-                # Meta-loss: maximize entropy (make forget data uncertain)
-                # This makes the model resistant to being fine-tuned on forget data
-                uniform_target = torch.full_like(logits, 1.0 / logits.size(-1))
-                meta_forget_loss = self.forget_weight * F.kl_div(
-                    F.log_softmax(logits, dim=-1),
+                for _inner in range(self.num_inner_steps):
+                    inner_optimizer.zero_grad()
+                    inner_logits = self._forward_logits(adapted_model, forget_inputs)
+                    inner_loss = F.cross_entropy(inner_logits, forget_labels)
+                    inner_loss.backward()
+                    inner_optimizer.step()
+
+                current_logits = self._forward_logits(model, forget_inputs)
+                uniform_target = torch.full_like(current_logits, 1.0 / current_logits.size(-1))
+                anti_relearn_loss = F.kl_div(
+                    F.log_softmax(current_logits, dim=-1),
                     uniform_target,
                     reduction="batchmean",
                 )
+                drift_penalty = self._parameter_drift(model, adapted_model)
+                outer_loss = (
+                    self.forget_weight * anti_relearn_loss
+                    + self.adaptation_penalty * drift_penalty
+                )
 
                 optimizer.zero_grad()
-                meta_forget_loss.backward()
+                outer_loss.backward()
                 optimizer.step()
 
-                epoch_forget += meta_forget_loss.item()
+                epoch_forget += float(outer_loss.item())
                 n_forget += 1
 
             forget_losses.append(epoch_forget / max(n_forget, 1))
 
-            # --- Retain pass: ensure retain data stays learnable ---
             if retain_loader is not None:
                 for retain_batch in retain_loader:
-                    retain_inputs, retain_labels = (
-                        retain_batch[0].to(device),
-                        retain_batch[1].to(device),
-                    )
+                    if not isinstance(retain_batch, (list, tuple)) or len(retain_batch) < 2:
+                        continue
 
-                    out = model(retain_inputs)
-                    logits = out.logits if hasattr(out, "logits") else out
-
-                    # Standard classification loss on retain data
-                    retain_loss = self.retain_weight * F.cross_entropy(
-                        logits, retain_labels
-                    )
+                    retain_inputs = retain_batch[0].to(device)
+                    retain_labels = retain_batch[1].to(device)
+                    retain_logits = self._forward_logits(model, retain_inputs)
+                    retain_loss = self.retain_weight * F.cross_entropy(retain_logits, retain_labels)
 
                     optimizer.zero_grad()
                     retain_loss.backward()
                     optimizer.step()
 
-                    epoch_retain += retain_loss.item()
+                    epoch_retain += float(retain_loss.item())
                     n_retain += 1
 
                 retain_losses.append(epoch_retain / max(n_retain, 1))
 
         return model, forget_losses, retain_losses
+
+    @staticmethod
+    def _forward_logits(model: nn.Module, inputs: torch.Tensor) -> torch.Tensor:
+        outputs = model(inputs)
+        return outputs.logits if hasattr(outputs, "logits") else outputs
+
+    @staticmethod
+    def _parameter_drift(model: nn.Module, adapted_model: nn.Module) -> torch.Tensor:
+        penalty = torch.tensor(0.0, device=next(model.parameters()).device)
+        for param, adapted_param in zip(model.parameters(), adapted_model.parameters()):
+            penalty = penalty + F.mse_loss(param, adapted_param.detach())
+        return penalty

--- a/erasus/strategies/gradient_methods/__init__.py
+++ b/erasus/strategies/gradient_methods/__init__.py
@@ -2,10 +2,14 @@
 
 from erasus.strategies.gradient_methods.gradient_ascent import GradientAscentStrategy
 from erasus.strategies.gradient_methods.modality_decoupling import ModalityDecouplingStrategy
-from erasus.strategies.gradient_methods.weighted_gradient_ascent import WGAStrategy
+from erasus.strategies.gradient_methods.weighted_gradient_ascent import (
+    FPGAStrategy,
+    WGAStrategy,
+)
 
 __all__ = [
     "GradientAscentStrategy",
     "ModalityDecouplingStrategy",
     "WGAStrategy",
+    "FPGAStrategy",
 ]

--- a/erasus/strategies/gradient_methods/weighted_gradient_ascent.py
+++ b/erasus/strategies/gradient_methods/weighted_gradient_ascent.py
@@ -1,18 +1,8 @@
 """
-WGA — Weighted Gradient Ascent for Targeted Unlearning.
+WGA / FPGA — weighted gradient ascent variants for targeted unlearning.
 
-Paper: "Weighted Gradient Ascent for Selective Unlearning" (2024)
-
-Key insight: Standard gradient ascent applies uniform gradients across all
-forget-set samples and tokens. WGA weights each gradient by per-token or
-per-sample importance, enabling fine-grained control over what gets unlearned.
-
-This produces more stable unlearning and preserves utility better than
-uniform gradient ascent, because tokens less important to the model's
-general capabilities are assigned higher unlearning priority.
-
-Loss: L = E_{x ∈ D_f}[w_i · ∇ log p_θ(y_i|x)]
-where w_i is the weight of token i (higher = more important to unlearn).
+WGA applies sample-level weighting, while FPGA extends this to
+token-level weighting for sequence-style forget batches.
 """
 
 from __future__ import annotations
@@ -31,27 +21,7 @@ from erasus.core.registry import strategy_registry
 @strategy_registry.register("wga")
 class WGAStrategy(BaseStrategy):
     """
-    WGA: Weighted Gradient Ascent for targeted unlearning.
-
-    Applies token-wise or sample-wise weights to gradient ascent updates,
-    allowing fine-grained control over unlearning strength. Tokens/samples
-    with higher weights contribute more to pushing the model toward
-    low-probability outputs.
-
-    Parameters
-    ----------
-    weighting : str
-        How to compute token weights. Options:
-        - ``"uniform"`` — all tokens equally weighted (equivalent to standard GA)
-        - ``"entropy"`` — weight by output entropy (high entropy tokens get higher weight)
-        - ``"confidence"`` — weight by prediction confidence (high-confidence tokens get higher weight)
-        Default: ``"entropy"``.
-    lr : float
-        Learning rate for gradient ascent (default 1e-3).
-    weight_scale : float
-        Multiplicative scale for computed weights (default 1.0).
-    retain_weight : float
-        Weight of retain KL loss (default 1.0).
+    Weighted gradient ascent for selective unlearning.
     """
 
     def __init__(
@@ -60,6 +30,7 @@ class WGAStrategy(BaseStrategy):
         lr: float = 1e-3,
         weight_scale: float = 1.0,
         retain_weight: float = 1.0,
+        token_weighted: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -67,6 +38,7 @@ class WGAStrategy(BaseStrategy):
         self.lr = lr
         self.weight_scale = weight_scale
         self.retain_weight = retain_weight
+        self.token_weighted = token_weighted
 
     def unlearn(
         self,
@@ -77,66 +49,49 @@ class WGAStrategy(BaseStrategy):
         **kwargs: Any,
     ) -> Tuple[nn.Module, List[float], List[float]]:
         device = next(model.parameters()).device
-
         model.train()
         optimizer = torch.optim.Adam(model.parameters(), lr=self.lr)
 
         forget_losses: List[float] = []
         retain_losses: List[float] = []
 
-        for epoch in range(epochs):
+        for _ in range(epochs):
             epoch_loss = 0.0
             epoch_retain = 0.0
             n_forget = 0
             n_retain = 0
 
-            # --- Forget pass: weighted gradient ascent ---
             for batch in forget_loader:
                 inputs, labels = batch[0].to(device), batch[1].to(device)
-
-                out = model(inputs)
-                logits = out.logits if hasattr(out, "logits") else out
-
-                # Compute per-token weights
+                outputs = model(inputs)
+                logits = outputs.logits if hasattr(outputs, "logits") else outputs
                 weights = self._compute_weights(logits, labels)
+                ce = self._per_target_loss(logits, labels)
 
-                # Weighted cross-entropy (gradient ascent): maximize loss
-                if labels.dim() == 1:
-                    true_logits = logits.gather(1, labels.unsqueeze(1)).squeeze(1)
+                if self.token_weighted and ce.dim() > 1:
+                    valid_mask = labels.ne(-100) if labels.shape == ce.shape else torch.ones_like(ce, dtype=torch.bool)
+                    weighted = weights * ce * valid_mask.to(ce.dtype)
+                    denom = valid_mask.sum().clamp_min(1).to(ce.dtype)
+                    loss = -weighted.sum() / denom
                 else:
-                    true_logits = logits.mean(dim=list(range(1, logits.dim())))
-
-                # Standard cross-entropy via log-softmax
-                log_probs = F.log_softmax(logits, dim=-1)
-                if labels.dim() == 1:
-                    ce = -log_probs.gather(1, labels.unsqueeze(1)).squeeze(1)
-                else:
-                    ce = -log_probs.mean(dim=list(range(1, log_probs.dim())))
-
-                # Apply weights and negate for gradient ascent
-                weighted_loss = -(weights * ce).mean()
+                    if ce.dim() > 1:
+                        ce = ce.mean(dim=-1)
+                    if weights.dim() > 1:
+                        weights = weights.mean(dim=-1)
+                    loss = -(weights * ce).mean()
 
                 optimizer.zero_grad()
-                weighted_loss.backward()
+                loss.backward()
                 optimizer.step()
 
-                epoch_loss += weighted_loss.item()
+                epoch_loss += loss.item()
                 n_forget += 1
 
             forget_losses.append(epoch_loss / max(n_forget, 1))
 
-            # --- Retain pass: KL divergence ---
             if retain_loader is not None:
                 for batch in retain_loader:
-                    inputs, labels = batch[0].to(device), batch[1].to(device)
-
-                    out = model(inputs)
-                    logits = out.logits if hasattr(out, "logits") else out
-
-                    # For retain data, we don't modify the loss — just ensure
-                    # the model doesn't degrade. In practice, this is often
-                    # done via a separate reference model + KL, but here we
-                    # use a lightweight L2 regularization on weights instead.
+                    inputs = batch[0].to(device)
                     weight_reg = sum(p.pow(2).sum() for p in model.parameters()) / 1000.0
                     retain_loss = self.retain_weight * weight_reg
 
@@ -151,40 +106,51 @@ class WGAStrategy(BaseStrategy):
 
         return model, forget_losses, retain_losses
 
+    def _per_target_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        log_probs = F.log_softmax(logits, dim=-1)
+        if logits.dim() == 2 and labels.dim() == 1:
+            return -log_probs.gather(1, labels.unsqueeze(1)).squeeze(1)
+        if logits.dim() >= 3 and labels.dim() == logits.dim() - 1:
+            safe_labels = labels.clamp_min(0)
+            return -log_probs.gather(-1, safe_labels.unsqueeze(-1)).squeeze(-1)
+        return -log_probs.mean(dim=-1)
+
     def _compute_weights(
         self,
         logits: torch.Tensor,
         labels: torch.Tensor,
     ) -> torch.Tensor:
-        """Compute per-token weights based on the weighting strategy."""
-        batch_size = logits.size(0)
+        probs = F.softmax(logits, dim=-1)
 
         if self.weighting == "uniform":
-            # All tokens equally weighted
-            return torch.ones(batch_size, device=logits.device)
+            return torch.ones_like(labels, dtype=logits.dtype, device=logits.device) if self.token_weighted and labels.dim() > 1 else torch.ones(logits.size(0), device=logits.device, dtype=logits.dtype)
 
-        elif self.weighting == "entropy":
-            # Weight by output entropy (high entropy = high weight)
-            probs = F.softmax(logits, dim=-1)
+        if self.weighting == "entropy":
             entropy = -(probs * torch.log(probs + 1e-8)).sum(dim=-1)
-            # Normalize to [0, weight_scale]
             entropy = entropy / (entropy.max() + 1e-8)
             return self.weight_scale * entropy
 
-        elif self.weighting == "confidence":
-            # Weight by prediction confidence on the true label
-            # High confidence = high weight (important to unlearn)
-            probs = F.softmax(logits, dim=-1)
-            if labels.dim() == 1:
+        if self.weighting == "confidence":
+            if logits.dim() == 2 and labels.dim() == 1:
                 true_probs = probs.gather(1, labels.unsqueeze(1)).squeeze(1)
+            elif logits.dim() >= 3 and labels.dim() == logits.dim() - 1:
+                safe_labels = labels.clamp_min(0)
+                true_probs = probs.gather(-1, safe_labels.unsqueeze(-1)).squeeze(-1)
             else:
-                true_probs = probs.mean(dim=list(range(1, probs.dim())))
-            # Higher confidence gets higher weight
-            weights = self.weight_scale * true_probs
-            return weights
+                true_probs = probs.max(dim=-1).values
+            return self.weight_scale * true_probs
 
-        else:
-            raise ValueError(
-                f"Unknown weighting '{self.weighting}'. "
-                "Choose from: 'uniform', 'entropy', 'confidence'."
-            )
+        raise ValueError(
+            f"Unknown weighting '{self.weighting}'. "
+            "Choose from: 'uniform', 'entropy', 'confidence'."
+        )
+
+
+@strategy_registry.register("fpga")
+class FPGAStrategy(WGAStrategy):
+    """
+    FPGA: token-weighted gradient ascent.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(token_weighted=True, **kwargs)

--- a/erasus/strategies/inference_time/__init__.py
+++ b/erasus/strategies/inference_time/__init__.py
@@ -10,10 +10,16 @@ Suitable for:
 - Rapid iteration without committing to permanent parameter changes
 """
 
+from erasus.strategies.inference_time.base import BaseInferenceTimeStrategy
 from erasus.strategies.inference_time.dexperts import DExpertsStrategy
 from erasus.strategies.inference_time.activation_steering import (
     ActivationSteeringStrategy,
     SteeringModel,
 )
 
-__all__ = ["DExpertsStrategy", "ActivationSteeringStrategy", "SteeringModel"]
+__all__ = [
+    "BaseInferenceTimeStrategy",
+    "DExpertsStrategy",
+    "ActivationSteeringStrategy",
+    "SteeringModel",
+]

--- a/erasus/strategies/inference_time/activation_steering.py
+++ b/erasus/strategies/inference_time/activation_steering.py
@@ -19,8 +19,8 @@ import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
-from erasus.core.base_strategy import BaseStrategy
 from erasus.core.registry import strategy_registry
+from erasus.strategies.inference_time.base import BaseInferenceTimeStrategy
 
 
 class ActivationSteeringHook:
@@ -73,7 +73,7 @@ class ActivationSteeringHook:
 
 
 @strategy_registry.register("activation_steering")
-class ActivationSteeringStrategy(BaseStrategy):
+class ActivationSteeringStrategy(BaseInferenceTimeStrategy):
     """
     Unlearning via activation steering.
 

--- a/erasus/strategies/inference_time/base.py
+++ b/erasus/strategies/inference_time/base.py
@@ -1,0 +1,20 @@
+"""
+Base helpers for inference-time unlearning strategies.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from erasus.core.base_strategy import BaseStrategy
+
+
+class BaseInferenceTimeStrategy(BaseStrategy):
+    """
+    Base class for inference-time strategies that do not train weights.
+    """
+
+    requires_training = False
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)

--- a/erasus/strategies/inference_time/dexperts.py
+++ b/erasus/strategies/inference_time/dexperts.py
@@ -1,25 +1,10 @@
 """
-DExperts — Inference-time unlearning via expert/anti-expert ensembling.
+DExperts — Inference-time unlearning via token-level expert ensembling.
 
-Paper: "DExperts: Decoding-Time Controlled Text Generation with
-Experts and Anti-Experts" (Liu et al., ACL 2021), adapted for
-machine unlearning (2024).
-
-DExperts requires no gradient computation on the base model.
-Instead it:
-
-1. Fine-tunes a small "anti-expert" model on the forget set
-   (this is the only training that happens).
-2. At inference time, combines three models:
-       logits = logits_base + α · (logits_expert - logits_anti)
-   where logits_expert = logits_base (base is its own expert)
-   and logits_anti is the anti-expert's output.
-
-The effect: tokens strongly predicted by the anti-expert (forget
-content) are suppressed; everything else is unchanged.
-
-``unlearn()`` returns a ``DExpertsWrapper`` — an ``nn.Module``
-whose ``forward()`` implements the ensemble computation.
+This implementation performs pure decoding-time ensembling and never
+updates the base model's weights. The expert defaults to the base model,
+while the anti-expert can be provided explicitly or defaults to a frozen
+copy of the base model.
 """
 
 from __future__ import annotations
@@ -29,19 +14,18 @@ from typing import Any, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
-from erasus.core.base_strategy import BaseStrategy
 from erasus.core.registry import strategy_registry
+from erasus.strategies.inference_time.base import BaseInferenceTimeStrategy
 
 
 class DExpertsWrapper(nn.Module):
     """
-    Wraps a base model and an anti-expert to compute ensemble logits.
+    Token-level expert/anti-expert ensemble wrapper.
 
-    forward() returns adjusted logits:
-        logits_base + alpha * (logits_base - logits_anti)
+    Combines logits as:
+        base + alpha * (expert - anti_expert)
     """
 
     def __init__(
@@ -49,9 +33,11 @@ class DExpertsWrapper(nn.Module):
         base_model: nn.Module,
         anti_expert: nn.Module,
         alpha: float = 1.0,
+        expert_model: Optional[nn.Module] = None,
     ) -> None:
         super().__init__()
         self.base_model = base_model
+        self.expert_model = expert_model or base_model
         self.anti_expert = anti_expert
         self.alpha = alpha
 
@@ -60,15 +46,15 @@ class DExpertsWrapper(nn.Module):
         base_logits = base_out.logits if hasattr(base_out, "logits") else base_out
 
         with torch.no_grad():
+            expert_out = self.expert_model(*args, **kwargs)
+            expert_logits = expert_out.logits if hasattr(expert_out, "logits") else expert_out
             anti_out = self.anti_expert(*args, **kwargs)
             anti_logits = anti_out.logits if hasattr(anti_out, "logits") else anti_out
 
-        # Suppress anti-expert tokens
-        adjusted = base_logits + self.alpha * (base_logits - anti_logits)
+        adjusted = base_logits + self.alpha * (expert_logits - anti_logits)
         return adjusted
 
     def __getattr__(self, name: str) -> Any:
-        """Proxy attribute access to base model for compatibility."""
         try:
             return super().__getattr__(name)
         except AttributeError:
@@ -76,34 +62,35 @@ class DExpertsWrapper(nn.Module):
 
 
 @strategy_registry.register("dexperts")
-class DExpertsStrategy(BaseStrategy):
+class DExpertsStrategy(BaseInferenceTimeStrategy):
     """
-    Inference-time unlearning via expert/anti-expert ensembling.
-
-    Does not modify the base model weights.  Trains an anti-expert on
-    the forget set, then returns a ``DExpertsWrapper`` that combines
-    them at inference time.
+    Inference-time unlearning without weight modification.
 
     Parameters
     ----------
     alpha : float
-        Suppression strength (default 1.0).  Higher values more
-        aggressively suppress forget-set tokens.
-    anti_expert_lr : float
-        Learning rate for fine-tuning the anti-expert (default 1e-4).
-    anti_expert_epochs : int
-        Epochs to train the anti-expert (default 3).
+        Strength of anti-expert suppression.
+    anti_expert_model : nn.Module, optional
+        Frozen anti-expert model. If omitted, a frozen copy of the base
+        model is used, which keeps the operation side-effect free.
+    expert_model : nn.Module, optional
+        Expert model to reinforce non-forget behavior. Defaults to the
+        base model.
     """
 
     def __init__(
         self,
         alpha: float = 1.0,
+        anti_expert_model: Optional[nn.Module] = None,
+        expert_model: Optional[nn.Module] = None,
         anti_expert_lr: float = 1e-4,
         anti_expert_epochs: int = 3,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.alpha = alpha
+        self.anti_expert_model = anti_expert_model
+        self.expert_model = expert_model
         self.anti_expert_lr = anti_expert_lr
         self.anti_expert_epochs = anti_expert_epochs
 
@@ -115,47 +102,24 @@ class DExpertsStrategy(BaseStrategy):
         epochs: int = 3,
         **kwargs: Any,
     ) -> Tuple[nn.Module, List[float], List[float]]:
+        del forget_loader, retain_loader, epochs
+
         device = next(model.parameters()).device
-
-        # Build anti-expert: fine-tune a copy on forget set
-        anti_expert = copy.deepcopy(model).to(device)
-        anti_expert.train()
-        optimizer = torch.optim.Adam(anti_expert.parameters(), lr=self.anti_expert_lr)
-        criterion = nn.CrossEntropyLoss()
-
-        anti_losses: List[float] = []
-        n_epochs = max(epochs, self.anti_expert_epochs)
-
-        for epoch in range(n_epochs):
-            epoch_loss = 0.0
-            n = 0
-            for batch in forget_loader:
-                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
-                    continue
-                inputs, labels = batch[0].to(device), batch[1].to(device)
-
-                optimizer.zero_grad()
-                out = anti_expert(inputs)
-                logits = out.logits if hasattr(out, "logits") else out
-                loss = criterion(logits, labels)
-                loss.backward()
-                optimizer.step()
-
-                epoch_loss += loss.item()
-                n += 1
-
-            anti_losses.append(epoch_loss / max(n, 1))
+        anti_expert = self.anti_expert_model
+        if anti_expert is None:
+            anti_expert = copy.deepcopy(model).to(device)
 
         anti_expert.eval()
-        for p in anti_expert.parameters():
-            p.requires_grad = False
+        for param in anti_expert.parameters():
+            param.requires_grad = False
 
-        # Return a wrapper — base model weights are NOT modified
+        expert_model = self.expert_model or model
+        expert_model.eval()
+
         wrapper = DExpertsWrapper(
             base_model=model,
+            expert_model=expert_model,
             anti_expert=anti_expert,
             alpha=self.alpha,
         )
-
-        # Return lists consistent with BaseStrategy contract
-        return wrapper, anti_losses, []
+        return wrapper, [], []

--- a/erasus/strategies/llm_specific/flat.py
+++ b/erasus/strategies/llm_specific/flat.py
@@ -1,27 +1,20 @@
 """
-FLAT — LLM Unlearning via Loss Adjustment.
+FLAT — LLM unlearning via loss adjustment.
 
-Paper: "FLAT: LLM Unlearning via Loss Adjustment with No Retain Data
-or Reference Model" (Li et al., ICLR 2025)
+Paper: "FLAT: LLM Unlearning via Loss Adjustment with No Retain Data"
+(Li et al., ICLR 2025)
 
-FLAT is the most practical preference-based method because it requires
-only the forget data — no retain set, no reference model.
+FLAT is designed to work with the forget set alone. This implementation
+uses a forget-only loss adjustment that combines:
 
-Two components:
-1. IDK loss (forget set): train the model to output maximum entropy
-   (I Don't Know) on forget-set queries.  For classifiers this is a
-   uniform target; for LLMs it is an "I don't know" token sequence.
-
-2. Maintain loss (retain set, optional): self-distillation — the model
-   KL-diverges toward its own pre-step output, preserving general
-   capabilities without a separate retain dataset.
-
-Loss: L = α · L_IDK + (1-α) · L_maintain
+1. An IDK / high-entropy term that pulls output distributions toward
+   uniformity on forget examples.
+2. A direct forget term that pushes down the average log-probability of
+   the forget labels/tokens.
 """
 
 from __future__ import annotations
 
-import copy
 from typing import Any, List, Optional, Tuple
 
 import torch
@@ -31,27 +24,31 @@ from torch.utils.data import DataLoader
 
 from erasus.core.base_strategy import BaseStrategy
 from erasus.core.registry import strategy_registry
+from erasus.strategies.llm_specific.simnpo import (
+    _forward_logits,
+    _split_batch,
+    _token_log_probs_and_mask,
+)
 
 
 @strategy_registry.register("flat")
 class FLATStrategy(BaseStrategy):
     """
-    FLAT: forget-data-only unlearning via loss adjustment.
+    Forget-only FLAT unlearning.
 
     Parameters
     ----------
     alpha : float
-        Weight of IDK loss vs maintain loss (default 0.5).
+        Interpolation between the IDK term and the direct forget term.
     idk_weight : float
-        Additional scaling of the IDK loss (default 1.0).
+        Scale applied to the uniform-target IDK term.
     maintain_weight : float
-        Additional scaling of the self-distillation loss (default 1.0).
+        Scale applied to the direct forget term.
     lr : float
-        Learning rate (default 1e-5).
+        Learning rate.
     n_maintain_steps : int
-        Number of self-distillation steps on the forget batch per
-        forget step (default 1).  Keeps general capabilities stable
-        without a separate retain loader.
+        Reserved for API compatibility; FLAT operates in a single
+        forget-only optimisation step per batch in this implementation.
     """
 
     def __init__(
@@ -78,6 +75,8 @@ class FLATStrategy(BaseStrategy):
         epochs: int = 5,
         **kwargs: Any,
     ) -> Tuple[nn.Module, List[float], List[float]]:
+        del retain_loader  # FLAT does not require retain data.
+
         device = next(model.parameters()).device
         model.train()
         optimizer = torch.optim.Adam(model.parameters(), lr=self.lr)
@@ -85,70 +84,26 @@ class FLATStrategy(BaseStrategy):
         forget_losses: List[float] = []
         retain_losses: List[float] = []
 
-        for epoch in range(epochs):
+        for _ in range(epochs):
             epoch_loss = 0.0
-            epoch_retain = 0.0
-            n = 0
-            n_retain = 0
-
-            forget_iter = iter(forget_loader)
-            retain_iter = iter(retain_loader) if retain_loader is not None else None
+            n_batches = 0
 
             for batch in forget_loader:
-                inputs, labels = batch[0].to(device), batch[1].to(device)
-
-                # --- Step 1: IDK loss ---
-                # Target: uniform distribution (maximum entropy = "I don't know")
-                out = model(inputs)
-                logits = out.logits if hasattr(out, "logits") else out
-                n_classes = logits.size(-1)
-
-                uniform_target = torch.full_like(logits, 1.0 / n_classes)
+                model_inputs, labels = _split_batch(batch, device)
+                logits = _forward_logits(model, model_inputs)
                 log_probs = F.log_softmax(logits, dim=-1)
+
+                uniform_target = torch.full_like(log_probs, 1.0 / log_probs.size(-1))
                 idk_loss = F.kl_div(log_probs, uniform_target, reduction="batchmean")
 
-                # --- Step 2: Maintain loss (self-distillation) ---
-                # Snapshot the model's current output before the IDK update
-                with torch.no_grad():
-                    snapshot_out = model(inputs)
-                    snapshot_logits = (
-                        snapshot_out.logits if hasattr(snapshot_out, "logits") else snapshot_out
-                    )
-                    snapshot_probs = F.softmax(snapshot_logits, dim=-1)
-
-                # After IDK update, distil back toward snapshot on *retain* data if available
-                # (when no retain data, apply maintain loss on the same forget batch)
-                if retain_loader is not None and retain_iter is not None:
-                    try:
-                        retain_batch = next(retain_iter)
-                    except StopIteration:
-                        retain_iter = iter(retain_loader)
-                        retain_batch = next(retain_iter)
-
-                    r_inputs = retain_batch[0].to(device)
-                    with torch.no_grad():
-                        r_snap_out = model(r_inputs)
-                        r_snap_logits = (
-                            r_snap_out.logits if hasattr(r_snap_out, "logits") else r_snap_out
-                        )
-                        r_snap_probs = F.softmax(r_snap_logits, dim=-1)
-
-                    r_out = model(r_inputs)
-                    r_logits = r_out.logits if hasattr(r_out, "logits") else r_out
-                    r_log_probs = F.log_softmax(r_logits, dim=-1)
-                    maintain_loss = F.kl_div(r_log_probs, r_snap_probs, reduction="batchmean")
-                    epoch_retain += maintain_loss.item()
-                    n_retain += 1
-                else:
-                    # Self-distillation on forget batch keeps the model stable
-                    out2 = model(inputs)
-                    logits2 = out2.logits if hasattr(out2, "logits") else out2
-                    log_probs2 = F.log_softmax(logits2, dim=-1)
-                    maintain_loss = F.kl_div(log_probs2, snapshot_probs, reduction="batchmean")
+                token_log_probs, valid_mask = _token_log_probs_and_mask(logits, labels)
+                token_log_probs = token_log_probs * valid_mask.to(token_log_probs.dtype)
+                token_counts = valid_mask.sum(dim=-1).clamp_min(1).to(logits.dtype)
+                forget_term = token_log_probs.sum(dim=-1) / token_counts
 
                 loss = (
                     self.alpha * self.idk_weight * idk_loss
-                    + (1 - self.alpha) * self.maintain_weight * maintain_loss
+                    + (1.0 - self.alpha) * self.maintain_weight * forget_term.mean()
                 )
 
                 optimizer.zero_grad()
@@ -156,10 +111,8 @@ class FLATStrategy(BaseStrategy):
                 optimizer.step()
 
                 epoch_loss += loss.item()
-                n += 1
+                n_batches += 1
 
-            forget_losses.append(epoch_loss / max(n, 1))
-            if retain_losses is not None and n_retain > 0:
-                retain_losses.append(epoch_retain / n_retain)
+            forget_losses.append(epoch_loss / max(n_batches, 1))
 
         return model, forget_losses, retain_losses

--- a/erasus/strategies/llm_specific/rmu.py
+++ b/erasus/strategies/llm_specific/rmu.py
@@ -13,8 +13,9 @@ removal).  Rather than modifying output distributions, RMU manipulates
 - For retain-set inputs: keep hidden states close to those of a frozen
   reference model (preservation).
 
-This operates at a deeper level than output-based methods and is
-substantially harder to reverse via benign fine-tuning.
+This operates at a deeper level than output-based methods by steering
+internal representations toward a control direction while preserving
+retain-set representations relative to a frozen snapshot.
 """
 
 from __future__ import annotations
@@ -42,9 +43,12 @@ class RMUStrategy(BaseStrategy):
         Indices of layers (by depth order in ``model.named_modules()``)
         at which to hook.  If None, uses the middle third of the network.
     alpha : float
-        Weight of the forget misdirection loss (default 1.0).
+        Weight of the forget steering loss (default 1.0).
     retain_weight : float
         Weight of the retain representation preservation loss (default 1.0).
+    steering_coefficient : float
+        Norm multiplier for the steering target relative to the current
+        hidden-state norm (default 1.0).
     lr : float
         Learning rate (default 1e-5).
     random_seed : int
@@ -56,6 +60,7 @@ class RMUStrategy(BaseStrategy):
         layer_ids: Optional[List[int]] = None,
         alpha: float = 1.0,
         retain_weight: float = 1.0,
+        steering_coefficient: float = 1.0,
         lr: float = 1e-5,
         random_seed: int = 42,
         **kwargs: Any,
@@ -64,6 +69,7 @@ class RMUStrategy(BaseStrategy):
         self.layer_ids = layer_ids
         self.alpha = alpha
         self.retain_weight = retain_weight
+        self.steering_coefficient = steering_coefficient
         self.lr = lr
         self.random_seed = random_seed
 
@@ -122,18 +128,14 @@ class RMUStrategy(BaseStrategy):
             for batch in forget_loader:
                 inputs = batch[0].to(device)
 
-                # Capture hidden states with forward hooks
                 forget_hidden = self._capture_hidden(model, inputs, hook_layers)
 
-                # Generate random misdirection targets (same shape as hidden states)
-                misdirection_loss = torch.tensor(0.0, device=device)
+                steering_loss = torch.tensor(0.0, device=device)
                 for name, hidden in forget_hidden.items():
-                    target = torch.randn_like(hidden, generator=rng)
-                    target = target / (target.norm(dim=-1, keepdim=True) + 1e-8)
-                    target = target * hidden.norm(dim=-1, keepdim=True).detach()
-                    misdirection_loss = misdirection_loss + F.mse_loss(hidden, target.detach())
+                    target = self._steering_target(hidden, rng)
+                    steering_loss = steering_loss + F.mse_loss(hidden, target)
 
-                loss = self.alpha * misdirection_loss / max(len(forget_hidden), 1)
+                loss = self.alpha * steering_loss / max(len(forget_hidden), 1)
 
                 optimizer.zero_grad()
                 loss.backward()
@@ -149,11 +151,9 @@ class RMUStrategy(BaseStrategy):
                 for batch in retain_loader:
                     inputs = batch[0].to(device)
 
-                    # Reference hidden states (frozen)
                     with torch.no_grad():
                         ref_hidden = self._capture_hidden(ref_model, inputs, hook_layers)
 
-                    # Student hidden states
                     student_hidden = self._capture_hidden(model, inputs, hook_layers)
 
                     preserve_loss = torch.tensor(0.0, device=device)
@@ -204,3 +204,18 @@ class RMUStrategy(BaseStrategy):
                 h.remove()
 
         return captured
+
+    def _steering_target(
+        self,
+        hidden: torch.Tensor,
+        rng: torch.Generator,
+    ) -> torch.Tensor:
+        """Construct a normalized steering vector for a hidden state tensor."""
+        target = torch.randn(hidden.shape, device=hidden.device, dtype=hidden.dtype, generator=rng)
+        flat_hidden = hidden.reshape(hidden.size(0), -1)
+        flat_target = target.reshape(target.size(0), -1)
+
+        hidden_norm = flat_hidden.norm(dim=-1, keepdim=True).clamp_min(1e-8)
+        target_norm = flat_target.norm(dim=-1, keepdim=True).clamp_min(1e-8)
+        scaled = flat_target / target_norm * hidden_norm * self.steering_coefficient
+        return scaled.reshape_as(hidden).detach()

--- a/erasus/strategies/llm_specific/simnpo.py
+++ b/erasus/strategies/llm_specific/simnpo.py
@@ -4,21 +4,15 @@ SimNPO — Simplified Negative Preference Optimization.
 Paper: "SimNPO: Simplicity Prevails: Rethinking Negative Preference
 Optimization for LLM Unlearning" (Fan et al., NeurIPS 2025)
 
-Key insight: NPO's reference model introduces a "reference model bias"
-that gives a misleading impression of unlearning effectiveness.  SimNPO
-removes the reference model dependency entirely, using only the forget
-set with a length-normalised negative preference loss.
-
-Loss: L = -E_{x∈D_f}[log σ(-β · (1/|x|) Σ log p_θ(xₜ|x_{<t}))]
-
-After successful unlearning, the model should produce near-uniform
-distributions on forget-set queries without degrading on retain data.
+SimNPO removes NPO's frozen reference model and optimises a single
+forget-only preference objective on the forget set. The core signal is
+the average log-probability assigned to the forget labels/tokens; the
+strategy pushes that quantity downward directly via a sigmoid loss.
 """
 
 from __future__ import annotations
 
-import copy
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -29,40 +23,96 @@ from erasus.core.base_strategy import BaseStrategy
 from erasus.core.registry import strategy_registry
 
 
+def _move_to_device(value: Any, device: torch.device) -> Any:
+    """Move tensors nested in common batch containers to the target device."""
+    if isinstance(value, torch.Tensor):
+        return value.to(device)
+    if isinstance(value, dict):
+        return {key: _move_to_device(val, device) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return type(value)(_move_to_device(val, device) for val in value)
+    return value
+
+
+def _split_batch(batch: Any, device: torch.device) -> Tuple[Any, Optional[torch.Tensor]]:
+    """Extract model inputs and labels from tuple- or dict-style batches."""
+    batch = _move_to_device(batch, device)
+    if isinstance(batch, dict):
+        labels = batch.get("labels")
+        return batch, labels
+    if isinstance(batch, (list, tuple)):
+        if len(batch) == 1:
+            return batch[0], None
+        return batch[0], batch[1]
+    return batch, None
+
+
+def _forward_logits(model: nn.Module, model_inputs: Any) -> torch.Tensor:
+    """Run the model and always return raw logits."""
+    outputs = model(**model_inputs) if isinstance(model_inputs, dict) else model(model_inputs)
+    return outputs.logits if hasattr(outputs, "logits") else outputs
+
+
+def _token_log_probs_and_mask(
+    logits: torch.Tensor,
+    labels: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Return target-token log-probabilities plus a validity mask.
+
+    Supports both standard classification ``(B, C)`` and token-level
+    language modeling ``(B, T, V)`` with ``ignore_index=-100`` labels.
+    """
+    log_probs = F.log_softmax(logits, dim=-1)
+
+    if labels is None:
+        values = log_probs.max(dim=-1).values
+        if values.dim() == 1:
+            values = values.unsqueeze(-1)
+        mask = torch.ones_like(values, dtype=torch.bool)
+        return values, mask
+
+    if logits.dim() == 2 and labels.dim() == 1:
+        gathered = log_probs.gather(1, labels.unsqueeze(1)).squeeze(1).unsqueeze(1)
+        mask = torch.ones_like(gathered, dtype=torch.bool)
+        return gathered, mask
+
+    if logits.dim() >= 3 and labels.dim() == logits.dim() - 1:
+        safe_labels = labels.clamp_min(0)
+        gathered = log_probs.gather(-1, safe_labels.unsqueeze(-1)).squeeze(-1)
+        mask = labels.ne(-100)
+        return gathered, mask
+
+    flat = log_probs.reshape(log_probs.size(0), -1).mean(dim=-1, keepdim=True)
+    mask = torch.ones_like(flat, dtype=torch.bool)
+    return flat, mask
+
+
 @strategy_registry.register("simnpo")
 class SimNPOStrategy(BaseStrategy):
     """
-    SimNPO: reference-free negative preference unlearning.
-
-    Trains the model to assign lower likelihood to forget-set sequences
-    via a length-normalised sigmoid loss, without needing a frozen
-    reference model.  An optional retain pass (KL against a snapshot)
-    preserves utility.
+    Reference-free negative preference optimisation on forget data only.
 
     Parameters
     ----------
     beta : float
-        Inverse temperature scaling the preference gap (default 0.1).
+        Inverse-temperature for the preference sigmoid.
     gamma : float
-        Length-normalisation floor to avoid division by zero (default 1.0).
-    retain_weight : float
-        Weight of the retain KL loss relative to the forget loss (default 1.0).
+        Minimum normalisation denominator when averaging token log-probs.
     lr : float
-        Learning rate (default 1e-5).
+        Learning rate.
     """
 
     def __init__(
         self,
         beta: float = 0.1,
         gamma: float = 1.0,
-        retain_weight: float = 1.0,
         lr: float = 1e-5,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.beta = beta
         self.gamma = gamma
-        self.retain_weight = retain_weight
         self.lr = lr
 
     def unlearn(
@@ -73,51 +123,29 @@ class SimNPOStrategy(BaseStrategy):
         epochs: int = 5,
         **kwargs: Any,
     ) -> Tuple[nn.Module, List[float], List[float]]:
+        del retain_loader  # SimNPO is forget-data-only by design.
+
         device = next(model.parameters()).device
-
-        # Snapshot for retain KL (frozen reference)
-        if retain_loader is not None:
-            ref_model = copy.deepcopy(model).to(device)
-            ref_model.eval()
-            for p in ref_model.parameters():
-                p.requires_grad = False
-        else:
-            ref_model = None
-
         model.train()
         optimizer = torch.optim.Adam(model.parameters(), lr=self.lr)
 
         forget_losses: List[float] = []
         retain_losses: List[float] = []
 
-        for epoch in range(epochs):
+        for _ in range(epochs):
             epoch_forget = 0.0
-            epoch_retain = 0.0
             n_forget = 0
-            n_retain = 0
 
-            # --- Forget pass: SimNPO loss ---
             for batch in forget_loader:
-                inputs, labels = batch[0].to(device), batch[1].to(device)
+                model_inputs, labels = _split_batch(batch, device)
+                logits = _forward_logits(model, model_inputs)
+                token_log_probs, valid_mask = _token_log_probs_and_mask(logits, labels)
 
-                outputs = model(inputs)
-                logits = outputs.logits if hasattr(outputs, "logits") else outputs
+                token_log_probs = token_log_probs * valid_mask.to(token_log_probs.dtype)
+                token_counts = valid_mask.sum(dim=-1).clamp_min(self.gamma).to(logits.dtype)
+                average_log_prob = token_log_probs.sum(dim=-1) / token_counts
 
-                # Per-sample log-probabilities of true labels
-                log_probs = F.log_softmax(logits, dim=-1)
-                # For classification: single log-prob per sample
-                if labels.dim() == 1:
-                    seq_log_prob = log_probs[range(len(labels)), labels]   # (B,)
-                    length = torch.ones_like(seq_log_prob) * max(self.gamma, 1.0)
-                else:
-                    # Sequence: average across positions
-                    seq_log_prob = log_probs.mean(dim=1).mean(dim=-1)
-                    length = torch.full((inputs.size(0),), max(self.gamma, inputs.size(1)),
-                                       device=device)
-
-                # Length-normalised negative preference loss
-                normalised = seq_log_prob / length
-                loss = -F.logsigmoid(-self.beta * normalised).mean()
+                loss = -F.logsigmoid(-self.beta * average_log_prob).mean()
 
                 optimizer.zero_grad()
                 loss.backward()
@@ -127,31 +155,5 @@ class SimNPOStrategy(BaseStrategy):
                 n_forget += 1
 
             forget_losses.append(epoch_forget / max(n_forget, 1))
-
-            # --- Retain pass: KL against frozen snapshot ---
-            if retain_loader is not None and ref_model is not None:
-                for batch in retain_loader:
-                    inputs = batch[0].to(device)
-
-                    with torch.no_grad():
-                        ref_out = ref_model(inputs)
-                        ref_logits = ref_out.logits if hasattr(ref_out, "logits") else ref_out
-                        ref_probs = F.softmax(ref_logits, dim=-1)
-
-                    out = model(inputs)
-                    logits = out.logits if hasattr(out, "logits") else out
-                    log_probs = F.log_softmax(logits, dim=-1)
-
-                    kl = F.kl_div(log_probs, ref_probs, reduction="batchmean")
-                    retain_loss = self.retain_weight * kl
-
-                    optimizer.zero_grad()
-                    retain_loss.backward()
-                    optimizer.step()
-
-                    epoch_retain += retain_loss.item()
-                    n_retain += 1
-
-                retain_losses.append(epoch_retain / max(n_retain, 1))
 
         return model, forget_losses, retain_losses

--- a/erasus/utils/__init__.py
+++ b/erasus/utils/__init__.py
@@ -1,5 +1,6 @@
 """erasus.utils — Utility functions and helpers."""
 
+from erasus.utils.decorators import experimental
 from erasus.utils.helpers import (
     count_parameters,
     model_size_mb,
@@ -32,6 +33,8 @@ from erasus.utils.profiling import UnlearningProfiler, profile_section, profile_
 from erasus.utils.reproducibility import make_reproducible, ExperimentSnapshot
 
 __all__ = [
+    # decorators
+    "experimental",
     # helpers
     "count_parameters",
     "model_size_mb",

--- a/erasus/utils/decorators.py
+++ b/erasus/utils/decorators.py
@@ -1,0 +1,55 @@
+"""
+erasus.utils.decorators — Shared utility decorators.
+"""
+
+from __future__ import annotations
+
+import functools
+import warnings
+from typing import Any, Callable, Optional, TypeVar, Union, cast
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def experimental(
+    obj: Optional[F] = None,
+    *,
+    message: Optional[str] = None,
+    category: type[Warning] = UserWarning,
+) -> Union[F, Callable[[F], F]]:
+    """
+    Mark a function or class as experimental.
+
+    The decorated target emits a warning when invoked/instantiated and
+    is annotated with ``__erasus_experimental__ = True``.
+    """
+
+    def decorator(target: F) -> F:
+        note = message or f"{target.__name__} is experimental and may change without notice."
+
+        if isinstance(target, type):
+            original_init = target.__init__
+
+            @functools.wraps(original_init)
+            def wrapped_init(self: Any, *args: Any, **kwargs: Any) -> None:
+                warnings.warn(note, category=category, stacklevel=2)
+                original_init(self, *args, **kwargs)
+
+            target.__init__ = wrapped_init  # type: ignore[method-assign]
+            setattr(target, "__erasus_experimental__", True)
+            setattr(target, "__erasus_experimental_message__", note)
+            return target
+
+        @functools.wraps(target)
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            warnings.warn(note, category=category, stacklevel=2)
+            return target(*args, **kwargs)
+
+        setattr(wrapped, "__erasus_experimental__", True)
+        setattr(wrapped, "__erasus_experimental_message__", note)
+        return cast(F, wrapped)
+
+    if obj is not None:
+        return decorator(obj)
+    return decorator

--- a/tests/unit/test_benchmarks.py
+++ b/tests/unit/test_benchmarks.py
@@ -13,6 +13,7 @@ from erasus.benchmarks import (
     TOFUEvaluator,
     LMEvalWrapper,
     LMEvalBenchmark,
+    PostUnlearningBenchmarkSuite,
     BenchmarkRunner,
     BenchmarkResult,
 )
@@ -242,6 +243,23 @@ class TestLMEvalBenchmark:
 
         # Just check it doesn't crash on instantiation
         assert benchmark.wrapper is not None
+
+
+class TestPostUnlearningBenchmarkSuite:
+    """Test the post-unlearning wrapper for standard tasks."""
+
+    def test_init(self, tiny_model, dummy_tokenizer):
+        suite = PostUnlearningBenchmarkSuite(tiny_model, dummy_tokenizer)
+        assert suite.benchmark is not None
+
+    def test_default_tasks(self):
+        assert PostUnlearningBenchmarkSuite.DEFAULT_TASKS == [
+            "mmlu",
+            "gsm8k",
+            "truthfulqa",
+            "hellaswag",
+            "arc",
+        ]
 
 
 class TestBenchmarkRunner:

--- a/tests/unit/test_experimental_decorator.py
+++ b/tests/unit/test_experimental_decorator.py
@@ -1,0 +1,36 @@
+"""
+Tests for the @experimental decorator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestExperimentalDecorator:
+    def test_function_warns_and_preserves_result(self):
+        from erasus.utils import experimental
+
+        @experimental
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        with pytest.warns(UserWarning, match="add is experimental"):
+            result = add(2, 3)
+
+        assert result == 5
+        assert getattr(add, "__erasus_experimental__", False) is True
+
+    def test_class_warns_on_instantiation(self):
+        from erasus.utils import experimental
+
+        @experimental(message="Toy is experimental.")
+        class Toy:
+            def __init__(self, value: int) -> None:
+                self.value = value
+
+        with pytest.warns(UserWarning, match="Toy is experimental."):
+            toy = Toy(7)
+
+        assert toy.value == 7
+        assert getattr(Toy, "__erasus_experimental__", False) is True

--- a/tests/unit/test_issue5.py
+++ b/tests/unit/test_issue5.py
@@ -553,6 +553,23 @@ class TestUnlearningBenchmark:
         assert "Protocol: tofu" in summary
         assert "Verdict:" in summary
 
+    def test_capability_delta_report(self):
+        from erasus.evaluation.benchmark_protocol import UnlearningBenchmark
+
+        baseline_model = _tiny_model()
+        unlearned_model = _tiny_model()
+        benchmark = UnlearningBenchmark(protocol="general", n_runs=1)
+        report = benchmark.evaluate(
+            unlearned_model=unlearned_model,
+            baseline_model=baseline_model,
+            forget_data=_loader(32, 8),
+            retain_data=_loader(64, 8),
+        )
+
+        assert "capability_delta_report" in report.metadata
+        assert "model_utility" in report.metadata["capability_delta_report"]
+        assert "delta" in report.metadata["capability_delta_report"]["model_utility"]
+
     def test_metric_result_confidence_interval(self):
         from erasus.evaluation.benchmark_protocol import MetricResult
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -12,7 +12,10 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from erasus.core.registry import metric_registry
 from erasus.metrics.accuracy import AccuracyMetric
+from erasus.metrics.forgetting.mia_variants import MinKProbMetric
+from erasus.metrics.forgetting.mia_variants import ZLibMIAMetric
 from erasus.metrics.metric_suite import MetricSuite
+from erasus.metrics.privacy.privacy_leakage import PrivacyLeakageMetric
 
 # Ensure metrics are registered
 import erasus.metrics  # noqa: F401
@@ -60,6 +63,15 @@ class TestMetricRegistry:
     def test_perplexity_registered(self):
         assert metric_registry.get("perplexity") is not None
 
+    def test_mink_registered(self):
+        assert metric_registry.get("mink") is not None
+
+    def test_zlib_mia_registered(self):
+        assert metric_registry.get("zlib_mia") is not None
+
+    def test_privacy_leakage_registered(self):
+        assert metric_registry.get("privacy_leakage") is not None
+
 
 class TestAccuracyMetric:
     """Test AccuracyMetric."""
@@ -101,3 +113,73 @@ class TestMetricSuite:
         suite = MetricSuite([])
         result = suite.run(model, forget_loader, retain_loader)
         assert isinstance(result, dict)
+
+
+class TestMinKProbMetric:
+    """Test Min-K forgetting metric."""
+
+    def test_compute_returns_expected_keys(self, model, forget_loader, retain_loader):
+        metric = MinKProbMetric(k_percent=25.0)
+        result = metric.compute(
+            model=model,
+            forget_data=forget_loader,
+            retain_data=retain_loader,
+        )
+
+        assert set(result) == {"mink_forget_mean", "mink_retain_mean", "mink_auc"}
+
+    def test_invalid_k_percent_raises(self):
+        with pytest.raises(ValueError):
+            MinKProbMetric(k_percent=0.0)
+
+
+class TestZLibMIAMetric:
+    """Test zlib-normalized MIA metric."""
+
+    def test_compute_returns_expected_keys(self, model, forget_loader, retain_loader):
+        metric = ZLibMIAMetric()
+        result = metric.compute(
+            model=model,
+            forget_data=forget_loader,
+            retain_data=retain_loader,
+        )
+
+        assert set(result) == {
+            "zlib_mia_forget_mean",
+            "zlib_mia_retain_mean",
+            "zlib_mia_auc",
+        }
+
+
+class TestStandaloneMemorizationModules:
+    """Ensure standalone metric modules remain importable."""
+
+    def test_direct_exact_memorization_import(self):
+        from erasus.metrics.forgetting.exact_memorization import ExactMemorizationMetric
+
+        metric = ExactMemorizationMetric()
+        assert metric.name == "exact_memorization"
+
+    def test_direct_extraction_strength_import(self):
+        from erasus.metrics.forgetting.extraction_strength import ExtractionStrengthMetric
+
+        metric = ExtractionStrengthMetric()
+        assert metric.name == "extraction_strength"
+
+
+class TestPrivacyLeakageMetric:
+    """Test privacy leakage metric."""
+
+    def test_compute_returns_expected_keys(self, model, forget_loader, retain_loader):
+        metric = PrivacyLeakageMetric()
+        result = metric.compute(
+            model=model,
+            forget_data=forget_loader,
+            retain_data=retain_loader,
+        )
+
+        assert set(result) == {
+            "privacy_leakage",
+            "privacy_forget_loss",
+            "privacy_retain_loss",
+        }

--- a/tests/unit/test_sota_strategies.py
+++ b/tests/unit/test_sota_strategies.py
@@ -9,7 +9,9 @@ import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, TensorDataset
 
+from erasus.core.base_strategy import BaseStrategy
 from erasus.core.registry import strategy_registry
+from erasus.strategies.inference_time.base import BaseInferenceTimeStrategy
 from erasus.strategies.llm_specific.npo import NPOStrategy
 from erasus.strategies.llm_specific.simnpo import SimNPOStrategy
 from erasus.strategies.llm_specific.altpo import AltPOStrategy
@@ -143,9 +145,10 @@ class TestSimNPOStrategy:
         assert "simnpo" in strategy_registry._registry
         strategy_cls = strategy_registry.get("simnpo")
         assert issubclass(strategy_cls, SimNPOStrategy)
+        assert issubclass(strategy_cls, BaseStrategy)
 
     def test_unlearn(self, tiny_classifier, forget_loader, retain_loader):
-        """Test unlearning without reference model dependency."""
+        """Test forget-only unlearning even when retain data is passed."""
         strategy = SimNPOStrategy(beta=0.1, lr=1e-3)
         model = tiny_classifier.train()
 
@@ -159,6 +162,7 @@ class TestSimNPOStrategy:
         assert isinstance(unlearned_model, nn.Module)
         assert len(forget_losses) == 2
         assert all(isinstance(l, float) for l in forget_losses)
+        assert len(retain_losses) == 0
 
     def test_no_reference_needed(self, tiny_classifier, forget_loader):
         """Test that SimNPO works without retain data."""
@@ -283,6 +287,7 @@ class TestFLATStrategy:
         assert "flat" in strategy_registry._registry
         strategy_cls = strategy_registry.get("flat")
         assert issubclass(strategy_cls, FLATStrategy)
+        assert issubclass(strategy_cls, BaseStrategy)
 
     def test_unlearn_no_retain(self, tiny_classifier, forget_loader):
         """Test unlearning without retain data (uses self-distillation)."""
@@ -301,7 +306,7 @@ class TestFLATStrategy:
         assert len(retain_losses) == 0
 
     def test_unlearn_with_retain(self, tiny_classifier, forget_loader, retain_loader):
-        """Test unlearning with retain data."""
+        """Test retain data is optional and ignored by forget-only FLAT."""
         strategy = FLATStrategy(alpha=0.5, lr=1e-3)
         model = tiny_classifier.train()
 
@@ -314,7 +319,7 @@ class TestFLATStrategy:
 
         assert isinstance(unlearned_model, nn.Module)
         assert len(forget_losses) == 2
-        assert len(retain_losses) == 2
+        assert len(retain_losses) == 0
 
     def test_alpha_variations(self, tiny_classifier, forget_loader):
         """Test different alpha values."""
@@ -428,10 +433,11 @@ class TestDExpertsStrategy:
         assert "dexperts" in strategy_registry._registry
         strategy_cls = strategy_registry.get("dexperts")
         assert issubclass(strategy_cls, DExpertsStrategy)
+        assert issubclass(strategy_cls, BaseInferenceTimeStrategy)
 
     def test_strategy_unlearn(self, tiny_classifier, forget_loader):
         """Test DExpertsStrategy unlearning."""
-        strategy = DExpertsStrategy(alpha=1.0, anti_expert_lr=1e-3, anti_expert_epochs=2)
+        strategy = DExpertsStrategy(alpha=1.0)
         model = tiny_classifier.eval()
 
         unlearned_wrapper, anti_losses, _ = strategy.unlearn(
@@ -442,8 +448,11 @@ class TestDExpertsStrategy:
 
         # DExpertsStrategy returns a wrapper, not a modified model
         assert isinstance(unlearned_wrapper, DExpertsWrapper)
-        assert len(anti_losses) == 2
-        assert all(isinstance(l, float) for l in anti_losses)
+        assert len(anti_losses) == 0
+
+    def test_requires_training_false(self):
+        strategy = DExpertsStrategy()
+        assert strategy.requires_training is False
 
     def test_no_weight_modification(self, tiny_classifier, forget_loader):
         """Test that base model weights are not modified."""

--- a/tests/unit/test_tier1_strategies.py
+++ b/tests/unit/test_tier1_strategies.py
@@ -11,7 +11,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from erasus.core.registry import strategy_registry
 from erasus.strategies.llm_specific.undial import UNDIALStrategy
-from erasus.strategies.gradient_methods.weighted_gradient_ascent import WGAStrategy
+from erasus.strategies.gradient_methods.weighted_gradient_ascent import FPGAStrategy, WGAStrategy
 from erasus.strategies.diffusion_specific.meta_unlearning import MetaUnlearningStrategy
 
 
@@ -164,6 +164,9 @@ class TestWGAStrategy:
         assert "wga" in strategy_registry._registry
         strategy_cls = strategy_registry.get("wga")
         assert issubclass(strategy_cls, WGAStrategy)
+        assert "fpga" in strategy_registry._registry
+        fpga_cls = strategy_registry.get("fpga")
+        assert issubclass(fpga_cls, FPGAStrategy)
 
     def test_unlearn_uniform(self, tiny_classifier, forget_loader):
         """Test unlearning with uniform weighting (like standard GA)."""
@@ -207,6 +210,10 @@ class TestWGAStrategy:
 
         assert isinstance(unlearned_model, nn.Module)
         assert len(forget_losses) == 1
+
+    def test_fpga_init(self):
+        strategy = FPGAStrategy()
+        assert strategy.token_weighted is True
 
     def test_invalid_weighting(self):
         """Test that invalid weighting strategy raises error."""

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -196,6 +196,16 @@ class TestVerbatimMemorization:
         assert "verbatim_memorization_forget" in results
         assert "verbatim_kl_retain" in results
 
+    def test_overlap_helpers(self):
+        from erasus.metrics.forgetting.memorization import VerbatimMemorizationMetric
+
+        assert VerbatimMemorizationMetric._ngram_overlap(
+            ["a", "b", "c", "d"], ["a", "b", "c", "x"], n=3
+        ) > 0.0
+        assert VerbatimMemorizationMetric._longest_common_substring_ratio(
+            ["a", "b", "c", "d"], ["x", "b", "c", "y"]
+        ) > 0.0
+
 
 # ===================================================================
 # Adversarial Evaluation
@@ -347,6 +357,7 @@ class TestLoRARelearning:
         assert result["test"] == "lora_relearning"
         assert "lora_params" in result
         assert "forget_accuracy_recovery" in result
+        assert "concept_revival" in result
         assert "passed" in result
 
     def test_does_not_modify_original(self, model, forget_loader, retain_loader):


### PR DESCRIPTION
## Summary
Adds a focused batch of unlearning robustness, inference-time strategy, forgetting-metric, and evaluation/reporting improvements on top of the current `main` branch.

## Detailed Diff Changes
### LLM and inference-time unlearning strategies
- Implements and refines `FLAT`, `SimNPO`, and `RMU` under `erasus/strategies/llm_specific/`.
- Adds `BaseInferenceTimeStrategy` with `requires_training = False`.
- Refactors `DExperts` into pure token-level expert/anti-expert ensembling with no base-model weight modification.
- Keeps `ActivationSteeringStrategy` inside the new inference-time strategy framework.
- Extends weighted gradient ascent with token-weighted `fpga` registration.
- Upgrades `MetaUnlearningStrategy` to an inner/outer anti-relearning loop.

### Forgetting, memorization, and privacy metrics
- Adds standalone `exact_memorization` and `extraction_strength` metric modules.
- Extends `mia_variants` with Min-K and zlib-normalized MIA metrics.
- Adds a MUSE-style `privacy_leakage` metric.
- Reworks verbatim memorization to use longest-common-substring and n-gram overlap detection.
- Wires ROUGE-L into forget-quality evaluation for sequence-style benchmark inputs.

### Robustness and benchmark reporting
- Extends LoRA relearning evaluation to measure concept revival after related-data fine-tuning.
- Adds a post-unlearning benchmark suite wrapper for MMLU, GSM8K, TruthfulQA, HellaSwag, and ARC.
- Adds a pre/post capability delta report to benchmark metadata and summary output.

### Utilities and tests
- Adds reusable `@experimental` decorator support in `erasus.utils`.
- Updates exports/registrations for the new metrics and strategies.
- Expands unit coverage across strategies, metrics, verification, benchmarks, and utils.

## Testing
- `python3 -m pytest tests/unit/test_sota_strategies.py tests/unit/test_tier1_strategies.py tests/unit/test_metrics.py tests/unit/test_verification.py tests/unit/test_benchmarks.py tests/unit/test_issue5.py tests/unit/test_experimental_decorator.py -q`
