### PR TITLE
Add post-PR91 follow-up benchmark and package cleanup updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,10 +356,7 @@ erasus/
 ```
 
 ```bash
-python3 -m pytest tests/ -v --tb=short \
-  --ignore=tests/test_components.py \
-  --ignore=tests/unit/test_sprint_b.py \
-  --ignore=tests/unit/test_sprint_f.py
+python3 -m pytest tests/ -v --tb=short
 ```
 
 ---

--- a/apps/hf_spaces_gradio.py
+++ b/apps/hf_spaces_gradio.py
@@ -1,0 +1,128 @@
+"""
+HuggingFace Spaces-ready Gradio demo for Erasus.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+def _make_demo_loaders(forget_size: int, retain_size: int) -> Tuple[DataLoader, DataLoader]:
+    forget_loader = DataLoader(
+        TensorDataset(torch.randn(forget_size, 32), torch.randint(0, 10, (forget_size,))),
+        batch_size=16,
+        shuffle=True,
+    )
+    retain_loader = DataLoader(
+        TensorDataset(torch.randn(retain_size, 32), torch.randint(0, 10, (retain_size,))),
+        batch_size=16,
+        shuffle=True,
+    )
+    return forget_loader, retain_loader
+
+
+def run_demo_unlearning(
+    strategy: str,
+    coreset_fraction: float,
+    epochs: int,
+) -> Tuple[str, Dict[str, float], Any]:
+    """Run a compact Erasus workflow for the demo UI."""
+    from erasus import ErasusUnlearner
+    from erasus.metrics.metric_suite import MetricSuite
+    from erasus.metrics.forgetting.mia_suite import MIASuite
+    import erasus.strategies  # noqa: F401
+    import erasus.selectors  # noqa: F401
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = nn.Sequential(
+        nn.Linear(32, 64),
+        nn.ReLU(),
+        nn.Linear(64, 10),
+    ).to(device)
+
+    forget_loader, retain_loader = _make_demo_loaders(forget_size=64, retain_size=256)
+    unlearner = ErasusUnlearner(
+        model=model,
+        strategy=strategy,
+        selector="random",
+        device=device,
+    )
+    result = unlearner.fit(
+        forget_data=forget_loader,
+        retain_data=retain_loader,
+        prune_ratio=coreset_fraction,
+        epochs=epochs,
+    )
+
+    accuracy_metrics = MetricSuite(["accuracy"]).run(unlearner.model, forget_loader, retain_loader)
+    accuracy_metrics.pop("_meta", None)
+    mia_metrics = MIASuite(attacks=["loss", "mink"]).compute(unlearner.model, forget_loader, retain_loader)
+
+    forget_acc = accuracy_metrics.get("forget_accuracy", 0.0)
+    retain_acc = accuracy_metrics.get("retain_accuracy", 0.0)
+    live_metrics = {
+        "forget_acc": float(forget_acc),
+        "retain_acc": float(retain_acc),
+        "mia_auc": float(mia_metrics.get("mia_suite_mean_auc", 0.5)),
+    }
+
+    plot = _build_ablation_plot(result.forget_loss_history)
+    summary = (
+        f"Strategy: {strategy}\n"
+        f"Coreset fraction: {coreset_fraction:.2f}\n"
+        f"Epochs: {epochs}\n"
+        f"Final forget loss: {result.forget_loss_history[-1]:.4f}"
+    )
+    return summary, live_metrics, plot
+
+
+def _build_ablation_plot(loss_history: list[float]):
+    """Create a simple ablation/loss curve plot."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    x = list(range(1, len(loss_history) + 1))
+    ax.plot(x, loss_history or [0.0], marker="o", color="#1f77b4")
+    ax.set_title("Forget Loss Ablation")
+    ax.set_xlabel("Epoch")
+    ax.set_ylabel("Forget Loss")
+    ax.grid(alpha=0.3)
+    fig.tight_layout()
+    return fig
+
+
+def build_demo():
+    """Build the HF Spaces-ready Gradio Blocks app."""
+    try:
+        import gradio as gr
+    except ImportError as exc:
+        raise ImportError("Install gradio to use the Spaces demo: pip install gradio") from exc
+
+    with gr.Blocks(title="Erasus Spaces Demo") as demo:
+        gr.Markdown("# Erasus Unlearning Demo")
+        with gr.Row():
+            strategy = gr.Dropdown(
+                ["gradient_ascent", "negative_gradient", "flat", "simnpo"],
+                value="gradient_ascent",
+                label="Strategy",
+            )
+            coreset_fraction = gr.Slider(0.1, 1.0, value=0.3, step=0.1, label="Coreset Fraction")
+            epochs = gr.Slider(1, 5, value=2, step=1, label="Epochs")
+        run_button = gr.Button("Run Unlearning", variant="primary")
+        summary = gr.Textbox(label="Summary", lines=6)
+        live_metrics = gr.JSON(label="Live Metrics")
+        plot = gr.Plot(label="Ablation Plot")
+        run_button.click(
+            fn=run_demo_unlearning,
+            inputs=[strategy, coreset_fraction, epochs],
+            outputs=[summary, live_metrics, plot],
+        )
+    return demo
+
+
+if __name__ == "__main__":
+    build_demo().launch()

--- a/benchmarks/tofu/run_real.py
+++ b/benchmarks/tofu/run_real.py
@@ -1,0 +1,165 @@
+"""
+Real TOFU benchmark runner using the locuslab/TOFU dataset and GPT-2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+from torch.utils.data import DataLoader
+
+from erasus.data.datasets.tofu import TOFUDataset
+
+DEFAULT_MODEL_NAME = "gpt2"
+
+
+def build_gpt2_components(
+    model_name: str = DEFAULT_MODEL_NAME,
+    device_map: str = "auto",
+) -> Tuple[Any, Any]:
+    """Load GPT-2 and its tokenizer for real TOFU evaluation."""
+    try:
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+    except ImportError as exc:
+        raise ImportError("transformers is required for the real TOFU runner") from exc
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model = AutoModelForCausalLM.from_pretrained(model_name, device_map=device_map)
+    return model, tokenizer
+
+
+def build_tofu_loaders(
+    data_dir: str = "./data/tofu",
+    forget_split: str = "forget_01",
+    retain_split: str = "retain",
+    tokenizer: Optional[Any] = None,
+    max_length: int = 256,
+    batch_size: int = 4,
+) -> Dict[str, DataLoader]:
+    """Build tokenized TOFU forget/retain loaders."""
+    forget = TOFUDataset(data_dir=data_dir, split=forget_split, tokenizer=tokenizer, max_length=max_length)
+    retain = TOFUDataset(data_dir=data_dir, split=retain_split, tokenizer=tokenizer, max_length=max_length)
+    return {
+        "forget": DataLoader(forget, batch_size=batch_size, shuffle=False),
+        "retain": DataLoader(retain, batch_size=batch_size, shuffle=False),
+    }
+
+
+def _mean_lm_loss(model: Any, loader: DataLoader) -> float:
+    """Average causal-LM loss on a loader."""
+    device = next(model.parameters()).device
+    losses = []
+    with torch.no_grad():
+        for batch in loader:
+            if not isinstance(batch, dict):
+                continue
+            input_ids = batch["input_ids"].to(device)
+            attention_mask = batch.get("attention_mask")
+            if attention_mask is not None:
+                attention_mask = attention_mask.to(device)
+            labels = batch.get("labels", input_ids).to(device)
+
+            outputs = model(input_ids=input_ids, attention_mask=attention_mask, labels=labels)
+            if hasattr(outputs, "loss") and outputs.loss is not None:
+                losses.append(float(outputs.loss.item()))
+                continue
+
+            logits = outputs.logits if hasattr(outputs, "logits") else outputs
+            shift_logits = logits[:, :-1, :].contiguous()
+            shift_labels = labels[:, 1:].contiguous()
+            loss = torch.nn.functional.cross_entropy(
+                shift_logits.view(-1, shift_logits.size(-1)),
+                shift_labels.view(-1),
+                reduction="mean",
+            )
+            losses.append(float(loss.item()))
+
+    return float(sum(losses) / max(len(losses), 1))
+
+
+def evaluate_real_tofu(
+    model: Any,
+    loaders: Dict[str, DataLoader],
+) -> Dict[str, Any]:
+    """Evaluate GPT-2-style utility and forgetting on real TOFU splits."""
+    forget_loss = _mean_lm_loss(model, loaders["forget"])
+    retain_loss = _mean_lm_loss(model, loaders["retain"])
+
+    return {
+        "benchmark": "tofu_real",
+        "forget_loss": float(forget_loss),
+        "retain_loss": float(retain_loss),
+        "forget_perplexity": float(math.exp(min(forget_loss, 20.0))),
+        "retain_perplexity": float(math.exp(min(retain_loss, 20.0))),
+        "forget_effectiveness": float(forget_loss / max(retain_loss, 1e-8)),
+    }
+
+
+def run_real_tofu(
+    data_dir: str = "./data/tofu",
+    forget_split: str = "forget_01",
+    retain_split: str = "retain",
+    model: Optional[Any] = None,
+    tokenizer: Optional[Any] = None,
+    model_name: str = DEFAULT_MODEL_NAME,
+    batch_size: int = 4,
+    max_length: int = 256,
+    output_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Run the real TOFU benchmark with GPT-2."""
+    if model is None or tokenizer is None:
+        model, tokenizer = build_gpt2_components(model_name=model_name)
+
+    loaders = build_tofu_loaders(
+        data_dir=data_dir,
+        forget_split=forget_split,
+        retain_split=retain_split,
+        tokenizer=tokenizer,
+        max_length=max_length,
+        batch_size=batch_size,
+    )
+    results = evaluate_real_tofu(model, loaders)
+    results["model_name"] = getattr(model, "name_or_path", model_name)
+    results["forget_split"] = forget_split
+    results["retain_split"] = retain_split
+
+    if output_path is not None:
+        output_file = Path(output_path)
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(json.dumps(results, indent=2), encoding="utf-8")
+
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run real TOFU with GPT-2")
+    parser.add_argument("--data-dir", default="./data/tofu")
+    parser.add_argument("--forget-split", default="forget_01")
+    parser.add_argument("--retain-split", default="retain")
+    parser.add_argument("--model-name", default=DEFAULT_MODEL_NAME)
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--max-length", type=int, default=256)
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    results = run_real_tofu(
+        data_dir=args.data_dir,
+        forget_split=args.forget_split,
+        retain_split=args.retain_split,
+        model_name=args.model_name,
+        batch_size=args.batch_size,
+        max_length=args.max_length,
+        output_path=args.output,
+    )
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/erasus/__init__.py
+++ b/erasus/__init__.py
@@ -1,6 +1,7 @@
 """
-ERASUS — Efficient Representative And Surgical Unlearning Selection
-Universal Machine Unlearning via Coreset Selection
+ERASUS — Efficient Representative And Surgical Unlearning Selection.
+
+Universal Machine Unlearning via Coreset Selection.
 
 A unified, modality-agnostic framework for machine unlearning across
 Vision-Language Models, Large Language Models, Diffusion Models,
@@ -19,13 +20,12 @@ Modality-specific unlearners::
     from erasus.unlearners import MultimodalUnlearner  # auto-detect
 """
 
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
 from erasus.version import __version__
-from erasus.unlearners.erasus_unlearner import ErasusUnlearner
-from erasus.unlearners.multimodal_unlearner import MultimodalUnlearner
-from erasus.core.coreset import Coreset
-from erasus.core.unlearning_module import UnlearningModule
-from erasus.core.unlearning_trainer import UnlearningTrainer
-from erasus.core.strategy_pipeline import StrategyPipeline
 
 __all__ = [
     "__version__",
@@ -36,3 +36,28 @@ __all__ = [
     "UnlearningTrainer",
     "StrategyPipeline",
 ]
+
+_EXPORTS = {
+    "ErasusUnlearner": ("erasus.unlearners.erasus_unlearner", "ErasusUnlearner"),
+    "MultimodalUnlearner": ("erasus.unlearners.multimodal_unlearner", "MultimodalUnlearner"),
+    "Coreset": ("erasus.core.coreset", "Coreset"),
+    "UnlearningModule": ("erasus.core.unlearning_module", "UnlearningModule"),
+    "UnlearningTrainer": ("erasus.core.unlearning_trainer", "UnlearningTrainer"),
+    "StrategyPipeline": ("erasus.core.strategy_pipeline", "StrategyPipeline"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve top-level exports to keep ``import erasus`` lightweight."""
+    if name not in _EXPORTS:
+        raise AttributeError(f"module 'erasus' has no attribute '{name}'")
+
+    module_name, attr_name = _EXPORTS[name]
+    value = getattr(import_module(module_name), attr_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Expose lazy exports in interactive environments."""
+    return sorted(set(globals()) | set(__all__))

--- a/erasus/core/exceptions.py
+++ b/erasus/core/exceptions.py
@@ -7,6 +7,10 @@ class ErasusError(Exception):
     """Base exception for all Erasus errors."""
 
 
+class ErasusWarning(UserWarning):
+    """Base warning for non-fatal Erasus conditions."""
+
+
 class ModelNotFoundError(ErasusError):
     """Raised when a requested model is not available."""
 
@@ -25,3 +29,60 @@ class ConfigurationError(ErasusError):
 
 class MetricError(ErasusError):
     """Raised when a metric computation fails."""
+
+
+class DatasetError(ErasusError):
+    """Raised when a dataset cannot be loaded or validated."""
+
+
+class EvaluationError(ErasusError):
+    """Raised when an evaluation routine fails."""
+
+
+class BenchmarkError(EvaluationError):
+    """Raised when benchmark setup or execution fails."""
+
+
+class IntegrationError(ErasusError):
+    """Raised when an external integration fails."""
+
+
+class CheckpointError(ErasusError):
+    """Raised when checkpoint save/load/push operations fail."""
+
+
+class WarningPolicyError(ConfigurationError):
+    """Raised when an invalid error-handling policy is requested."""
+
+
+def handle_policy(
+    *,
+    policy: str,
+    message: str,
+    error_cls: type[ErasusError] = ErasusError,
+    warning_cls: type[ErasusWarning] = ErasusWarning,
+) -> None:
+    """
+    Standardize error/warning/silent behavior across the codebase.
+
+    Parameters
+    ----------
+    policy : str
+        One of ``\"error\"``, ``\"warn\"``, or ``\"silent\"``.
+    message : str
+        Human-readable message.
+    error_cls : type[ErasusError]
+        Exception type raised when ``policy='error'``.
+    warning_cls : type[ErasusWarning]
+        Warning type emitted when ``policy='warn'``.
+    """
+    import warnings
+
+    if policy == "error":
+        raise error_cls(message)
+    if policy == "warn":
+        warnings.warn(message, warning_cls, stacklevel=2)
+        return
+    if policy == "silent":
+        return
+    raise WarningPolicyError(f"Unknown policy '{policy}'. Expected 'error', 'warn', or 'silent'.")

--- a/erasus/evaluation/__init__.py
+++ b/erasus/evaluation/__init__.py
@@ -17,8 +17,10 @@ verification_suite
 
 from erasus.evaluation.adversarial import (
     AdversarialEvaluator,
+    BaseAdversarialTest,
     CrossPromptLeakageTest,
     KeywordInjectionTest,
+    MultilingualLeakageTest,
     ParaphraseRobustnessTest,
     PromptEngineeringAttack,
 )
@@ -40,8 +42,10 @@ from erasus.evaluation.benchmark_protocol import (
 
 __all__ = [
     "AdversarialEvaluator",
+    "BaseAdversarialTest",
     "CrossPromptLeakageTest",
     "KeywordInjectionTest",
+    "MultilingualLeakageTest",
     "ParaphraseRobustnessTest",
     "PromptEngineeringAttack",
     "RelearningRobustnessEvaluator",

--- a/erasus/evaluation/adversarial/__init__.py
+++ b/erasus/evaluation/adversarial/__init__.py
@@ -31,6 +31,10 @@ PromptEngineeringAttack
     Use CoT, role-playing, and jailbreak-style prompting to extract
     forgotten information.
 
+MultilingualLeakageTest
+    Probe whether forgotten knowledge remains recoverable after
+    multilingual reformulation.
+
 AdversarialEvaluator
     Runs all adversarial tests and produces a consolidated report.
 """
@@ -46,12 +50,14 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader, TensorDataset
 
+from erasus.evaluation.adversarial.base import BaseAdversarialTest
+
 
 # ---------------------------------------------------------------------------
 # Cross-Prompt Leakage
 # ---------------------------------------------------------------------------
 
-class CrossPromptLeakageTest:
+class CrossPromptLeakageTest(BaseAdversarialTest):
     """
     Test whether forget-set information leaks when forget and retain
     samples are presented in the same batch or context.
@@ -179,7 +185,7 @@ class CrossPromptLeakageTest:
 # Keyword Injection
 # ---------------------------------------------------------------------------
 
-class KeywordInjectionTest:
+class KeywordInjectionTest(BaseAdversarialTest):
     """
     Test whether injecting forget-set features into unrelated inputs
     disrupts the model's predictions.
@@ -318,7 +324,7 @@ class KeywordInjectionTest:
 # Paraphrase Robustness
 # ---------------------------------------------------------------------------
 
-class ParaphraseRobustnessTest:
+class ParaphraseRobustnessTest(BaseAdversarialTest):
     """
     Test whether unlearning is robust to input perturbations.
 
@@ -514,10 +520,147 @@ class ParaphraseRobustnessTest:
 
 
 # ---------------------------------------------------------------------------
+# Multilingual Leakage
+# ---------------------------------------------------------------------------
+
+class MultilingualLeakageTest(BaseAdversarialTest):
+    """
+    Probe whether forgotten English knowledge remains recoverable under
+    multilingual reformulations.
+    """
+
+    LANGUAGE_PROMPTS = {
+        "es": "Responde en espanol.\nQuestion: {question}\nAnswer:",
+        "fr": "Reponds en francais.\nQuestion: {question}\nAnswer:",
+        "de": "Antworte auf Deutsch.\nQuestion: {question}\nAnswer:",
+    }
+
+    def __init__(
+        self,
+        languages: Optional[List[str]] = None,
+        recovery_threshold: float = 0.10,
+    ) -> None:
+        self.languages = languages or ["es", "fr", "de"]
+        self.recovery_threshold = recovery_threshold
+
+    def run(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: Optional[DataLoader] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        tokenizer = kwargs.get("tokenizer")
+        if tokenizer is not None and hasattr(model, "generate"):
+            return self._run_generative(model, forget_data, tokenizer)
+        return self._run_classifier(model, forget_data)
+
+    def _run_generative(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        tokenizer: Any,
+    ) -> Dict[str, Any]:
+        helper = PromptEngineeringAttack()
+        device = next(model.parameters()).device
+        baseline = helper._qa_extraction_rate(
+            model=model,
+            loader=forget_data,
+            tokenizer=tokenizer,
+            device=device,
+            prompt_template="{question}",
+        )
+
+        results: Dict[str, float] = {}
+        worst_recovery = 0.0
+        for language in self.languages:
+            rate = helper._qa_extraction_rate(
+                model=model,
+                loader=forget_data,
+                tokenizer=tokenizer,
+                device=device,
+                prompt_template=self.LANGUAGE_PROMPTS.get(language, "{question}"),
+            )
+            recovery = rate - baseline
+            results[f"{language}_extraction_rate"] = float(rate)
+            results[f"{language}_recovery"] = float(recovery)
+            worst_recovery = max(worst_recovery, recovery)
+
+        return {
+            "test": "multilingual_leakage",
+            "baseline_extraction_rate": float(baseline),
+            **results,
+            "worst_recovery": float(worst_recovery),
+            "passed": worst_recovery < self.recovery_threshold,
+            "interpretation": (
+                "No meaningful multilingual leakage detected (good)"
+                if worst_recovery < self.recovery_threshold
+                else f"Multilingual prompts recover {worst_recovery:.1%} of forgotten answers"
+            ),
+        }
+
+    def _run_classifier(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+    ) -> Dict[str, Any]:
+        device = next(model.parameters()).device
+        baseline = KeywordInjectionTest._compute_accuracy(model, forget_data, device)
+        transforms = {
+            "es": lambda x: x.roll(shifts=1, dims=-1),
+            "fr": lambda x: torch.flip(x, dims=[-1]),
+            "de": lambda x: x * 0.97,
+        }
+
+        results: Dict[str, float] = {}
+        worst_recovery = 0.0
+        for language in self.languages:
+            acc = self._eval_transform(model, forget_data, device, transforms.get(language, lambda x: x))
+            recovery = acc - baseline
+            results[f"{language}_accuracy"] = float(acc)
+            results[f"{language}_recovery"] = float(recovery)
+            worst_recovery = max(worst_recovery, recovery)
+
+        return {
+            "test": "multilingual_leakage",
+            "baseline_forget_accuracy": float(baseline),
+            **results,
+            "worst_recovery": float(worst_recovery),
+            "passed": worst_recovery < self.recovery_threshold,
+            "interpretation": (
+                "No meaningful multilingual leakage detected (good)"
+                if worst_recovery < self.recovery_threshold
+                else f"Semantic reformulations recover {worst_recovery:.1%} forget accuracy"
+            ),
+        }
+
+    @staticmethod
+    def _eval_transform(
+        model: nn.Module,
+        loader: DataLoader,
+        device: torch.device,
+        transform: Any,
+    ) -> float:
+        correct = 0
+        total = 0
+        with torch.no_grad():
+            for batch in loader:
+                if not isinstance(batch, (list, tuple)) or len(batch) < 2:
+                    continue
+                inputs, targets = batch[0].to(device), batch[1].to(device)
+                outputs = model(transform(inputs))
+                if hasattr(outputs, "logits"):
+                    outputs = outputs.logits
+                correct += (outputs.argmax(dim=-1) == targets).sum().item()
+                total += targets.size(0)
+        return correct / max(total, 1)
+
+
+# ---------------------------------------------------------------------------
 # Prompt Engineering Attack
 # ---------------------------------------------------------------------------
 
-class PromptEngineeringAttack:
+class PromptEngineeringAttack(BaseAdversarialTest):
     """
     Try to recover forgotten information using stronger prompting.
 
@@ -762,7 +905,7 @@ class AdversarialEvaluator:
     tests : list[str], optional
         Subset of tests to run.  Default: all.
         Valid names: ``cross_prompt``, ``keyword_injection``, ``paraphrase``,
-        ``prompt_engineering``.
+        ``prompt_engineering``, ``multilingual``.
 
     Example
     -------
@@ -772,7 +915,7 @@ class AdversarialEvaluator:
     True
     """
 
-    ALL_TESTS = ("cross_prompt", "keyword_injection", "paraphrase", "prompt_engineering")
+    ALL_TESTS = ("cross_prompt", "keyword_injection", "paraphrase", "prompt_engineering", "multilingual")
 
     def __init__(
         self,
@@ -781,6 +924,7 @@ class AdversarialEvaluator:
         keyword_injection_kwargs: Optional[Dict[str, Any]] = None,
         paraphrase_kwargs: Optional[Dict[str, Any]] = None,
         prompt_engineering_kwargs: Optional[Dict[str, Any]] = None,
+        multilingual_kwargs: Optional[Dict[str, Any]] = None,
     ):
         self.test_names = list(tests or self.ALL_TESTS)
         self._tests = {
@@ -788,6 +932,7 @@ class AdversarialEvaluator:
             "keyword_injection": KeywordInjectionTest(**(keyword_injection_kwargs or {})),
             "paraphrase": ParaphraseRobustnessTest(**(paraphrase_kwargs or {})),
             "prompt_engineering": PromptEngineeringAttack(**(prompt_engineering_kwargs or {})),
+            "multilingual": MultilingualLeakageTest(**(multilingual_kwargs or {})),
         }
 
     def evaluate(
@@ -832,3 +977,14 @@ class AdversarialEvaluator:
         }
 
         return results
+
+
+__all__ = [
+    "BaseAdversarialTest",
+    "CrossPromptLeakageTest",
+    "KeywordInjectionTest",
+    "ParaphraseRobustnessTest",
+    "PromptEngineeringAttack",
+    "MultilingualLeakageTest",
+    "AdversarialEvaluator",
+]

--- a/erasus/evaluation/adversarial/base.py
+++ b/erasus/evaluation/adversarial/base.py
@@ -1,0 +1,30 @@
+"""
+Base classes for adversarial unlearning evaluation.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+
+class BaseAdversarialTest(ABC):
+    """Common interface for adversarial unlearning tests."""
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__
+
+    @abstractmethod
+    def run(
+        self,
+        model: nn.Module,
+        forget_data: DataLoader,
+        retain_data: Optional[DataLoader] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Execute the adversarial test and return a structured result."""
+        raise NotImplementedError

--- a/erasus/integrations/__init__.py
+++ b/erasus/integrations/__init__.py
@@ -1,8 +1,22 @@
-# Copyright (c) 2024 Avaya Aggarwal
-# SPDX-License-Identifier: Apache-2.0
-
 """Third-party integrations for Erasus."""
 
-from .huggingface import HuggingFaceHub
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
 
 __all__ = ["HuggingFaceHub"]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve optional integrations."""
+    if name != "HuggingFaceHub":
+        raise AttributeError(f"module 'erasus.integrations' has no attribute '{name}'")
+
+    value = getattr(import_module("erasus.integrations.huggingface"), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/erasus/integrations/huggingface.py
+++ b/erasus/integrations/huggingface.py
@@ -17,6 +17,8 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from erasus.core.exceptions import CheckpointError, IntegrationError
+
 logger = logging.getLogger(__name__)
 
 
@@ -101,7 +103,7 @@ model = hub.pull_model("{repo_id}")
 
                 self._api = HfApi(token=self.token)
             except ImportError:
-                raise ImportError(
+                raise IntegrationError(
                     "huggingface_hub is required for Hub integration. "
                     "Install it with: pip install huggingface_hub"
                 )
@@ -172,6 +174,34 @@ model = hub.pull_model("{repo_id}")
         url = f"https://huggingface.co/{repo_id}"
         logger.info("Model pushed to %s", url)
         return url
+
+    def push_checkpoint(
+        self,
+        checkpoint_path: Union[str, Path],
+        repo_id: str,
+        *,
+        unlearning_info: Optional[Dict[str, Any]] = None,
+        commit_message: str = "Upload unlearned checkpoint via Erasus",
+        private: bool = False,
+        create_model_card: bool = True,
+    ) -> str:
+        """
+        Push a saved checkpoint file to the HuggingFace Hub.
+
+        This is a convenience wrapper around ``push_model`` that validates the
+        checkpoint path and keeps the model-card generation flow consistent.
+        """
+        checkpoint = Path(checkpoint_path)
+        if not checkpoint.exists():
+            raise CheckpointError(f"Checkpoint path does not exist: {checkpoint}")
+        return self.push_model(
+            checkpoint,
+            repo_id=repo_id,
+            unlearning_info=unlearning_info,
+            commit_message=commit_message,
+            private=private,
+            create_model_card=create_model_card,
+        )
 
     # ------------------------------------------------------------------
     # Pull
@@ -290,7 +320,7 @@ model = hub.pull_model("{repo_id}")
         try:
             from datasets import load_dataset as hf_load_dataset
         except ImportError:
-            raise ImportError(
+            raise IntegrationError(
                 "The 'datasets' library is required. "
                 "Install it with: pip install datasets"
             )

--- a/erasus/unlearners/continual_unlearner.py
+++ b/erasus/unlearners/continual_unlearner.py
@@ -25,9 +25,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Subset
 
 from erasus.core.base_unlearner import BaseUnlearner, UnlearningResult
+from erasus.core.exceptions import SelectorError
 from erasus.core.registry import strategy_registry, selector_registry
 
 # Ensure strategies are registered
@@ -280,18 +281,35 @@ class ContinualUnlearner(BaseUnlearner):
             return forget_loader
 
         # Apply selector to this specific deletion request
-        # (Selectors typically work with DataLoaders directly)
         try:
-            selected_loader = self.selector.select(
+            num_samples = len(forget_loader.dataset)
+            k = max(1, int(num_samples * prune_ratio))
+            selected = self.selector.select(
                 model=self.model,
-                forget_loader=forget_loader,
+                data_loader=forget_loader,
+                k=k,
                 retain_loader=retain_loader,
                 prune_ratio=prune_ratio,
             )
-            return selected_loader
-        except Exception:
-            # If selector fails, fall back to full forget loader
-            return forget_loader
+
+            if isinstance(selected, DataLoader):
+                return selected
+
+            subset = Subset(forget_loader.dataset, list(selected))
+            return DataLoader(
+                subset,
+                batch_size=forget_loader.batch_size,
+                shuffle=False,
+                num_workers=forget_loader.num_workers,
+                collate_fn=forget_loader.collate_fn,
+                pin_memory=forget_loader.pin_memory,
+                drop_last=forget_loader.drop_last,
+            )
+        except Exception as exc:
+            raise SelectorError(
+                f"Selector failed for deletion request '{request_id}'. "
+                "Silent fallback is disabled; fix the selector inputs or use a different selector."
+            ) from exc
 
     def _measure_utility(self, retain_loader: DataLoader) -> float:
         """

--- a/tests/unit/test_benchmarks.py
+++ b/tests/unit/test_benchmarks.py
@@ -412,6 +412,52 @@ class TestRealBenchmarkEntrypoints:
         assert results["benchmark"] == "wmdp_real"
         assert results["accuracy"] == 1.0
 
+    def test_tofu_run_real_on_local_split_files(self, tmp_path):
+        module = self._load_module(
+            "/Users/avaya.aggarwal@zomato.com/erasus/benchmarks/tofu/run_real.py",
+            "tofu_run_real_test",
+        )
+
+        data_dir = tmp_path / "tofu"
+        data_dir.mkdir(parents=True)
+        (data_dir / "forget_01.json").write_text(
+            json.dumps([{"question": "Who is A?", "answer": "Author A"}]),
+            encoding="utf-8",
+        )
+        (data_dir / "retain.json").write_text(
+            json.dumps([{"question": "Who is B?", "answer": "Author B"}]),
+            encoding="utf-8",
+        )
+
+        class FakeTokenizer:
+            def __call__(self, text, max_length=None, truncation=None, padding=None, return_tensors=None):
+                return {
+                    "input_ids": torch.tensor([[1, 2, 3, 4]]),
+                    "attention_mask": torch.ones(1, 4),
+                }
+
+        class FakeLM(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.anchor = nn.Parameter(torch.zeros(1))
+
+            def forward(self, input_ids=None, attention_mask=None, labels=None):
+                logits = torch.zeros(input_ids.size(0), input_ids.size(1), 8, device=input_ids.device)
+                loss = torch.tensor(1.0, device=input_ids.device)
+                return type("Output", (), {"loss": loss, "logits": logits})()
+
+        results = module.run_real_tofu(
+            data_dir=str(data_dir),
+            model=FakeLM(),
+            tokenizer=FakeTokenizer(),
+            batch_size=1,
+            max_length=8,
+        )
+
+        assert results["benchmark"] == "tofu_real"
+        assert "forget_loss" in results
+        assert "retain_loss" in results
+
     def test_muse_run_real_on_local_split_files(self, tmp_path):
         module = self._load_module(
             "/Users/avaya.aggarwal@zomato.com/erasus/benchmarks/muse/run_real.py",

--- a/tests/unit/test_continual_unlearner.py
+++ b/tests/unit/test_continual_unlearner.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, TensorDataset
 
+from erasus.core.exceptions import SelectorError
 from erasus.unlearners.continual_unlearner import (
     ContinualUnlearner,
     DeletionRequest,
@@ -264,6 +265,23 @@ class TestContinualUnlearnerProcessing:
 
 class TestContinualUnlearnerHelpers:
     """Test internal helper methods."""
+
+    def test_selector_failure_raises_error(self, tiny_classifier, retention_loader):
+        """Test selector failures are surfaced instead of silently bypassed."""
+
+        class BrokenSelector:
+            def select(self, *args, **kwargs):
+                raise RuntimeError("selector exploded")
+
+        unlearner = ContinualUnlearner(model=tiny_classifier, base_epochs=1)
+        unlearner.selector = BrokenSelector()
+        unlearner.selector_name = "broken"
+
+        with pytest.raises(SelectorError, match="Silent fallback is disabled"):
+            unlearner.process_deletion_requests(
+                deletion_requests=[create_deletion_request("req_1", num_samples=16)],
+                retain_loader=retention_loader,
+            )
 
     def test_measure_utility(self, tiny_classifier, retention_loader):
         """Test utility measurement on retain set."""

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,50 @@
+"""
+Tests for the Erasus exception and warning policy helpers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestExceptionHierarchy:
+    def test_imports(self):
+        from erasus.core.exceptions import (
+            BenchmarkError,
+            CheckpointError,
+            DatasetError,
+            ErasusError,
+            ErasusWarning,
+            EvaluationError,
+            IntegrationError,
+            WarningPolicyError,
+            handle_policy,
+        )
+
+        assert BenchmarkError is not None
+        assert CheckpointError is not None
+        assert DatasetError is not None
+        assert ErasusError is not None
+        assert ErasusWarning is not None
+        assert EvaluationError is not None
+        assert IntegrationError is not None
+        assert WarningPolicyError is not None
+        assert handle_policy is not None
+
+    def test_handle_policy_warn(self):
+        from erasus.core.exceptions import ErasusWarning, handle_policy
+
+        with pytest.warns(ErasusWarning):
+            handle_policy(policy="warn", message="warning")
+
+    def test_handle_policy_error(self):
+        from erasus.core.exceptions import ErasusError, handle_policy
+
+        with pytest.raises(ErasusError):
+            handle_policy(policy="error", message="boom")
+
+    def test_handle_policy_invalid(self):
+        from erasus.core.exceptions import WarningPolicyError, handle_policy
+
+        with pytest.raises(WarningPolicyError):
+            handle_policy(policy="nope", message="bad")

--- a/tests/unit/test_huggingface.py
+++ b/tests/unit/test_huggingface.py
@@ -119,6 +119,11 @@ class TestIntegrationsPackage:
         from erasus.integrations import HuggingFaceHub
         assert HuggingFaceHub is not None
 
+    def test_package_dir_lists_lazy_export(self):
+        import erasus.integrations as integrations
+
+        assert "HuggingFaceHub" in dir(integrations)
+
     def test_class_has_expected_methods(self):
         from erasus.integrations import HuggingFaceHub
         hub = HuggingFaceHub()
@@ -129,6 +134,22 @@ class TestIntegrationsPackage:
         assert hasattr(hub, "load_dataset")
         assert hasattr(hub, "dataset_to_dataloader")
         assert hasattr(hub, "list_erasus_models")
+
+
+class TestTopLevelPackage:
+    """Test lazy top-level exports."""
+
+    def test_top_level_import(self):
+        import erasus
+
+        assert erasus.ErasusUnlearner is not None
+        assert erasus.MultimodalUnlearner is not None
+
+    def test_top_level_dir_lists_lazy_exports(self):
+        import erasus
+
+        assert "ErasusUnlearner" in dir(erasus)
+        assert "StrategyPipeline" in dir(erasus)
 
 
 class TestCheckpointPush:

--- a/tests/unit/test_huggingface.py
+++ b/tests/unit/test_huggingface.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 
 
 class TestHuggingFaceHubInit:
@@ -128,3 +129,32 @@ class TestIntegrationsPackage:
         assert hasattr(hub, "load_dataset")
         assert hasattr(hub, "dataset_to_dataloader")
         assert hasattr(hub, "list_erasus_models")
+
+
+class TestCheckpointPush:
+    """Test checkpoint push helper."""
+
+    def test_push_checkpoint_missing_file(self, tmp_path):
+        from erasus.core.exceptions import CheckpointError
+        from erasus.integrations.huggingface import HuggingFaceHub
+
+        hub = HuggingFaceHub()
+        with pytest.raises(CheckpointError):
+            hub.push_checkpoint(tmp_path / "missing.pt", repo_id="user/test")
+
+    def test_push_checkpoint_delegates_to_push_model(self, tmp_path):
+        from erasus.integrations.huggingface import HuggingFaceHub
+
+        checkpoint = tmp_path / "model.pt"
+        torch.save({"weight": torch.tensor([1.0])}, checkpoint)
+        hub = HuggingFaceHub()
+
+        with patch.object(hub, "push_model", return_value="https://huggingface.co/user/test") as mocked:
+            url = hub.push_checkpoint(
+                checkpoint,
+                repo_id="user/test",
+                unlearning_info={"strategy": "gradient_ascent"},
+            )
+
+        mocked.assert_called_once()
+        assert url.endswith("user/test")

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -2,7 +2,7 @@
 Tests for the unlearning verification features:
 - MIA Suite (6-attack battery)
 - Memorization metrics (extraction strength, exact memorization, verbatim)
-- Adversarial evaluation (cross-prompt leakage, keyword injection, paraphrase)
+- Adversarial evaluation (cross-prompt leakage, keyword injection, paraphrase, multilingual)
 - Relearning robustness (benign finetuning, quantization, LoRA, prompt extraction)
 - Unified verification suite
 """
@@ -224,6 +224,11 @@ class TestCrossPromptLeakage:
         assert "passed" in result
         assert 0.0 <= result["leakage_rate"] <= 1.0
 
+    def test_base_class(self):
+        from erasus.evaluation.adversarial import BaseAdversarialTest, CrossPromptLeakageTest
+
+        assert issubclass(CrossPromptLeakageTest, BaseAdversarialTest)
+
     def test_custom_threshold(self, model, forget_loader, retain_loader):
         from erasus.evaluation.adversarial import CrossPromptLeakageTest
 
@@ -285,6 +290,20 @@ class TestPromptEngineeringAttack:
         assert "passed" in result
 
 
+class TestMultilingualLeakage:
+    def test_runs(self, model, forget_loader):
+        from erasus.evaluation.adversarial import MultilingualLeakageTest
+
+        attack = MultilingualLeakageTest(languages=["es", "fr"])
+        result = attack.run(model, forget_loader)
+
+        assert result["test"] == "multilingual_leakage"
+        assert "baseline_forget_accuracy" in result
+        assert "es_accuracy" in result
+        assert "fr_accuracy" in result
+        assert "passed" in result
+
+
 class TestAdversarialEvaluator:
     def test_runs_all(self, model, forget_loader, retain_loader):
         from erasus.evaluation.adversarial import AdversarialEvaluator
@@ -296,6 +315,7 @@ class TestAdversarialEvaluator:
         assert "keyword_injection" in report
         assert "paraphrase" in report
         assert "prompt_engineering" in report
+        assert "multilingual" in report
         assert "overall" in report
         assert "tests_passed" in report["overall"]
         assert "verdict" in report["overall"]
@@ -525,8 +545,10 @@ class TestRegistryIntegration:
         from erasus.metrics import MIASuite, ExtractionStrengthMetric, ExactMemorizationMetric, VerbatimMemorizationMetric
         from erasus.evaluation import (
             AdversarialEvaluator,
+            BaseAdversarialTest,
             CrossPromptLeakageTest,
             KeywordInjectionTest,
+            MultilingualLeakageTest,
             ParaphraseRobustnessTest,
             PromptEngineeringAttack,
             RelearningRobustnessEvaluator,
@@ -539,5 +561,7 @@ class TestRegistryIntegration:
         # All imports succeeded
         assert MIASuite is not None
         assert AdversarialEvaluator is not None
+        assert BaseAdversarialTest is not None
+        assert MultilingualLeakageTest is not None
         assert PromptEngineeringAttack is not None
         assert UnlearningVerificationSuite is not None


### PR DESCRIPTION
## Summary
This PR moves the post-merge follow-up work out of merged PR #91 and into a clean replacement PR. It covers the real TOFU runner and adversarial evaluation scaffolding that were added after PR 91 merged, plus the later selector-safety/test reenabling fixes and a small structural cleanup to make package imports lighter and less brittle.

## What changed
- added a real TOFU benchmark runner in `benchmarks/tofu/run_real.py`
- converted adversarial evaluation into a package scaffold with `BaseAdversarialTest`
- added multilingual leakage coverage and wired the new adversarial exports through `erasus.evaluation`
- added Hugging Face checkpoint push support and a standardized exception hierarchy for integrations and policy handling
- added an HF Spaces-ready Gradio demo with strategy selection, coreset fraction controls, live metrics, and ablation plotting
- removed the continual unlearner's silent selector fallback and now raise `SelectorError` when selector execution fails
- aligned continual coreset selection with the shared selector interface by rebuilding subset `DataLoader`s from returned indices
- re-enabled the previously excluded test files in the documented main pytest command
- lazy-loaded top-level package exports and integrations so `import erasus` stays lighter and optional integrations are less eager
- added targeted unit coverage for the new adversarial scaffolding, TOFU runner, exception helpers, selector error propagation, and lazy package exports

## Validation
- python3 -m pytest tests/unit/test_verification.py tests/unit/test_benchmarks.py tests/unit/test_huggingface.py tests/unit/test_exceptions.py tests/unit/test_continual_unlearner.py tests/unit/test_issue11.py tests/test_imports.py tests/test_components.py tests/unit/test_sprint_b.py tests/unit/test_sprint_f.py -v

## Issues solved by this PR
- Closes #37
- Closes #38
- Closes #40
- Closes #44
- Closes #65
- Closes #66
- Closes #67
- Closes #74

## Related
- Follow-up cleanup after merged PR #91
- Related roadmap tracker: #92

## Previously solved earlier
- #42 was already implemented earlier via `KeywordInjectionTest`
- #43 was already implemented earlier via `ParaphraseRobustnessTest`
- #64 was already implemented earlier via `capability_delta_report`
