### PR TITLE
Roadmap: public API, benchmarks suite, FastAPI service, tracking, YAML, checkpoints, profiling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,13 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
         args: [--maxkb=500]
+
+  # Minimal smoke: root public API + stability metadata (fast; no downloads).
+  - repo: local
+    hooks:
+      - id: pytest-public-api
+        name: pytest (public API smoke)
+        language: system
+        entry: python3 -m pytest tests/unit/test_public_api.py -q
+        pass_filenames: false
+        always_run: true

--- a/configs/example_full_run.yaml
+++ b/configs/example_full_run.yaml
@@ -1,0 +1,41 @@
+# Full experiment layout (nested). Also compatible: flat keys like model_name / strategy
+# in configs/default.yaml — both merge into the same runtime ErasusConfig.
+#
+#   erasus unlearn --config configs/example_full_run.yaml
+#   erasus unlearn --config configs/example_full_run.yaml --override strategy.epochs=3
+
+experiment_name: erasus_full_run
+
+model:
+  name: openai/clip-vit-base-patch32
+  model_type: vlm
+  device: cuda
+
+data:
+  forget_data_dir: null   # set to your forget-set path
+  retain_data_dir: null
+  batch_size: 32
+
+strategy:
+  name: modality_decoupling
+  lr: 1.0e-4
+  epochs: 10
+  extra_params:
+    vision_lr: 1.0e-5
+    text_lr: 1.0e-4
+    alignment_weight: 0.1
+
+selector:
+  name: influence
+  prune_ratio: 0.1
+  extra_params: {}
+
+metrics:
+  - accuracy
+  - mia
+
+tracking:
+  backend: local        # local | wandb | mlflow
+  project: erasus
+  wandb_project: null
+  log_dir: null

--- a/erasus/__init__.py
+++ b/erasus/__init__.py
@@ -18,6 +18,19 @@ Modality-specific unlearners::
 
     from erasus.unlearners import VLMUnlearner, LLMUnlearner, DiffusionUnlearner
     from erasus.unlearners import MultimodalUnlearner  # auto-detect
+
+Public API stability (package root)
+-----------------------------------
+Exports are split into **stable** (semver-minded; breaking changes only on
+minor/major bumps) and **experimental** (may change without notice).
+
+- ``STABLE_EXPORTS``: names intended for downstream imports.
+- ``EXPERIMENTAL_EXPORTS``: names for early adopters and research code.
+- ``PUBLIC_API_STATUS``: mapping of export name → ``\"stable\"`` or
+  ``\"experimental\"``.
+
+Subpackages (e.g. ``erasus.strategies``, ``erasus.benchmarks``) define their
+own ``PUBLIC_API_STATUS`` for registered classes; see those modules' docs.
 """
 
 from __future__ import annotations

--- a/erasus/benchmarks/micro_protocol.py
+++ b/erasus/benchmarks/micro_protocol.py
@@ -1,0 +1,77 @@
+"""
+Lightweight protocol runs for the standard benchmark suite (no external data).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+import erasus.strategies  # noqa: F401 — register strategies
+from erasus.core.registry import strategy_registry
+from erasus.evaluation.benchmark_protocol import UnlearningBenchmark
+
+
+def run_micro_protocol(
+    protocol: str,
+    *,
+    epochs: int = 1,
+    strategy_name: str = "gradient_ascent",
+) -> Dict[str, Any]:
+    """
+    Run a single synthetic unlearning pass and evaluate with ``UnlearningBenchmark``.
+
+    Parameters
+    ----------
+    protocol
+        One of ``tofu``, ``muse``, ``wmdp``, ``general`` (``custom`` maps to ``general``).
+    """
+    if protocol == "custom":
+        protocol = "general"
+
+    in_dim, n_classes = 32, 10
+    n_forget, n_retain = 64, 128
+    model = nn.Sequential(
+        nn.Linear(in_dim, 32),
+        nn.ReLU(),
+        nn.Linear(32, n_classes),
+    )
+    forget_loader = DataLoader(
+        TensorDataset(
+            torch.randn(n_forget, in_dim),
+            torch.randint(0, n_classes, (n_forget,)),
+        ),
+        batch_size=16,
+    )
+    retain_loader = DataLoader(
+        TensorDataset(
+            torch.randn(n_retain, in_dim),
+            torch.randint(0, n_classes, (n_retain,)),
+        ),
+        batch_size=16,
+    )
+
+    strategy_cls = strategy_registry.get(strategy_name)
+    strategy = strategy_cls(lr=1e-3)
+    t0 = time.perf_counter()
+    model, fl, rl = strategy.unlearn(
+        model, forget_loader, retain_loader, epochs=epochs,
+    )
+    elapsed = time.perf_counter() - t0
+
+    benchmark = UnlearningBenchmark(protocol=protocol, n_runs=1)
+    report = benchmark.evaluate(model, forget_loader, retain_loader)
+
+    return {
+        "status": "ok",
+        "time_s": round(elapsed, 4),
+        "verdict": report.verdict,
+        "strategy": strategy_name,
+        "protocol": protocol,
+        "final_forget_loss": fl[-1] if fl else None,
+        "final_retain_loss": rl[-1] if rl else None,
+    }

--- a/erasus/benchmarks/standard_suite.py
+++ b/erasus/benchmarks/standard_suite.py
@@ -28,12 +28,15 @@ class BenchmarkSuiteReport:
         lines = [
             "# Standard Benchmark Suite",
             "",
-            "| Benchmark | Status | Notes |",
+            "| Benchmark | Status | Verdict / notes |",
             "| --- | --- | --- |",
         ]
         for entry in self.entries:
-            notes = entry.details.get("notes", "")
-            lines.append(f"| {entry.name} | {entry.status} | {notes} |")
+            if entry.status == "error":
+                cell = entry.details.get("error", "")
+            else:
+                cell = entry.details.get("verdict") or entry.details.get("notes", "")
+            lines.append(f"| {entry.name} | {entry.status} | {cell} |")
         return "\n".join(lines)
 
 
@@ -46,15 +49,27 @@ class StandardBenchmarkSuite:
         self.benchmarks = list(benchmarks or self.DEFAULT_BENCHMARKS)
 
     def run(self) -> BenchmarkSuiteReport:
+        from erasus.benchmarks.micro_protocol import run_micro_protocol
+
         entries = []
         for benchmark in self.benchmarks:
-            entries.append(
-                BenchmarkSuiteEntry(
-                    name=benchmark,
-                    status="configured",
-                    details={"notes": f"{benchmark} runner is available through the standard suite"},
+            try:
+                details = run_micro_protocol(benchmark, epochs=1)
+                entries.append(
+                    BenchmarkSuiteEntry(
+                        name=benchmark,
+                        status=details.get("status", "ok"),
+                        details=details,
+                    ),
                 )
-            )
+            except Exception as exc:
+                entries.append(
+                    BenchmarkSuiteEntry(
+                        name=benchmark,
+                        status="error",
+                        details={"error": str(exc)},
+                    ),
+                )
         return BenchmarkSuiteReport(entries=entries)
 
     def save_report(

--- a/erasus/cli/main.py
+++ b/erasus/cli/main.py
@@ -58,6 +58,14 @@ def main() -> None:
     add_service_args(service_parser)
     service_parser.set_defaults(func=run_service)
 
+    from erasus.cli.profile import add_profile_args, run_profile
+    profile_parser = subparsers.add_parser(
+        "profile",
+        help="Time/memory breakdown for selector + unlearning on synthetic data.",
+    )
+    add_profile_args(profile_parser)
+    profile_parser.set_defaults(func=run_profile)
+
     # Legacy --config support (redirect to unlearn)
     parser.add_argument(
         "--config", "-c", type=str, default=None,

--- a/erasus/cli/profile.py
+++ b/erasus/cli/profile.py
@@ -1,0 +1,73 @@
+"""
+``erasus profile`` — quick timing / memory breakdown for unlearning phases.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+def add_profile_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--output-json",
+        type=str,
+        default=None,
+        help="Write profiler report JSON to this path.",
+    )
+
+
+def run_profile(args: argparse.Namespace) -> None:
+    import erasus.strategies  # noqa: F401
+    from erasus.core.registry import selector_registry, strategy_registry
+    from erasus.utils.profiling import UnlearningProfiler
+
+    in_dim, n_classes = 32, 10
+    n_forget, n_retain = 64, 128
+    model = nn.Sequential(
+        nn.Linear(in_dim, 32),
+        nn.ReLU(),
+        nn.Linear(32, n_classes),
+    )
+    forget_loader = DataLoader(
+        TensorDataset(
+            torch.randn(n_forget, in_dim),
+            torch.randint(0, n_classes, (n_forget,)),
+        ),
+        batch_size=16,
+    )
+    retain_loader = DataLoader(
+        TensorDataset(
+            torch.randn(n_retain, in_dim),
+            torch.randint(0, n_classes, (n_retain,)),
+        ),
+        batch_size=16,
+    )
+
+    profiler = UnlearningProfiler(enable_cuda=torch.cuda.is_available())
+    report: dict[str, Any] = {}
+
+    with profiler.profile("selector"):
+        sel = selector_registry.get("random")()
+        _ = sel.select(model=model, data_loader=forget_loader, k=min(8, n_forget))
+
+    with profiler.profile("forward_backward_unlearning"):
+        strat = strategy_registry.get("gradient_ascent")(lr=1e-3)
+        model, fl, rl = strat.unlearn(
+            model, forget_loader, retain_loader, epochs=1,
+        )
+
+    profiler.log_memory("after_unlearning")
+    profiler.count_parameters(model, "unlearned_model")
+    report = profiler.get_report()
+    print(profiler.summary())
+
+    if args.output_json:
+        Path(args.output_json).write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print(f"  JSON report: {args.output_json}")

--- a/erasus/cli/unlearn.py
+++ b/erasus/cli/unlearn.py
@@ -98,6 +98,47 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Whether the monitored metric should be minimised or maximised (default: max).",
     )
 
+    ckpt_group = parser.add_argument_group("checkpointing & resume")
+    ckpt_group.add_argument(
+        "--resume-from",
+        type=str,
+        default=None,
+        help="Checkpoint dir or .pt from a previous run (see unlearning_checkpoint.*).",
+    )
+    ckpt_group.add_argument(
+        "--checkpoint-dir",
+        type=str,
+        default=None,
+        help="Directory to save periodic checkpoints (requires --checkpoint-every > 0).",
+    )
+    ckpt_group.add_argument(
+        "--checkpoint-every",
+        type=int,
+        default=0,
+        help="Save checkpoint every N epochs (0 = disabled).",
+    )
+
+    track_group = parser.add_argument_group("experiment tracking (W&B / MLflow / local)")
+    track_group.add_argument(
+        "--tracking-backend",
+        type=str,
+        default=None,
+        choices=["local", "wandb", "mlflow"],
+        help="Override tracking backend from config (default: config or local).",
+    )
+    track_group.add_argument(
+        "--tracking-project",
+        type=str,
+        default=None,
+        help="Project name for wandb/mlflow.",
+    )
+
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        help="Print UnlearningProfiler timing for the fit() call.",
+    )
+
     parser.set_defaults(func=run_unlearn)
 
 
@@ -147,7 +188,6 @@ def _build_dataloader(data_dir: str, batch_size: int = 32) -> Optional[torch.uti
 def run_unlearn(args: argparse.Namespace) -> None:
     """Execute the unlearning pipeline."""
     from erasus.core.config import ErasusConfig
-    from erasus.core.registry import strategy_registry, selector_registry
     from erasus.experiments.hydra_config import compose_experiment_config
 
     # ---- Load config ----
@@ -177,12 +217,16 @@ def run_unlearn(args: argparse.Namespace) -> None:
     print("=" * 60)
     print("  ERASUS — Machine Unlearning Pipeline")
     print("=" * 60)
+    print(f"  Experiment: {getattr(config, 'experiment_name', 'erasus_run')}")
     print(f"  Model   : {config.model_name} ({config.model_type})")
     print(f"  Strategy: {config.strategy}")
     print(f"  Selector: {config.selector}")
     print(f"  Epochs  : {config.epochs}")
     print(f"  Device  : {config.device}")
     print(f"  Prune   : {config.prune_ratio:.0%}")
+    print(f"  Metrics : {getattr(config, 'metrics', ['accuracy'])}")
+    tb = getattr(config, "tracking_backend", "local")
+    print(f"  Tracking: {tb} (project={getattr(config, 'tracking_project', 'erasus')})")
     if args.coreset_k:
         print(f"  Coreset k: {args.coreset_k}")
     if args.validate_every > 0:
@@ -191,6 +235,11 @@ def run_unlearn(args: argparse.Namespace) -> None:
         print(f"  Early stop: patience={args.early_stop_patience}, "
               f"monitor={args.early_stop_monitor} ({args.early_stop_mode})")
     print("=" * 60)
+
+    if args.tracking_backend:
+        config.tracking_backend = args.tracking_backend
+    if args.tracking_project:
+        config.tracking_project = args.tracking_project
 
     if args.dry_run:
         print("\n[DRY-RUN] Config is valid.  Full parameter dump:")
@@ -259,6 +308,7 @@ def run_unlearn(args: argparse.Namespace) -> None:
         validation_metrics = None
         if args.validate_every > 0:
             from erasus.metrics import MetricSuite
+
             validation_metrics = MetricSuite(["accuracy"]).metrics
 
         # ---- Run unlearning ----
@@ -278,8 +328,22 @@ def run_unlearn(args: argparse.Namespace) -> None:
             fit_kwargs["coreset"] = coreset_obj
         if validation_metrics is not None:
             fit_kwargs["validation_metrics"] = validation_metrics
+        if args.resume_from:
+            fit_kwargs["resume_from"] = args.resume_from
+        if args.checkpoint_dir:
+            fit_kwargs["checkpoint_dir"] = args.checkpoint_dir
+        if args.checkpoint_every:
+            fit_kwargs["checkpoint_every"] = args.checkpoint_every
 
-        result = unlearner.fit(**fit_kwargs)
+        if args.profile:
+            from erasus.utils.profiling import UnlearningProfiler
+
+            profiler = UnlearningProfiler()
+            with profiler.profile("unlearning_fit"):
+                result = unlearner.fit(**fit_kwargs)
+            print(profiler.summary())
+        else:
+            result = unlearner.fit(**fit_kwargs)
         elapsed = time.time() - t0
         print(f"  ✓ Unlearning complete in {elapsed:.1f}s")
         print(f"    Coreset: {result.coreset_size}/{result.original_forget_size} "
@@ -288,6 +352,55 @@ def run_unlearn(args: argparse.Namespace) -> None:
             print(f"    Final forget loss: {result.forget_loss_history[-1]:.4f}")
         if result.retain_loss_history:
             print(f"    Final retain loss: {result.retain_loss_history[-1]:.4f}")
+
+        eval_metrics: dict = {}
+        mnames = getattr(config, "metrics", None) or ["accuracy"]
+        try:
+            from erasus.metrics import MetricSuite
+
+            suite = MetricSuite(mnames)
+            eval_metrics = suite.run(unlearner.model, forget_loader, retain_loader or forget_loader)
+            print(f"    Metrics: {eval_metrics}")
+        except Exception as me:
+            print(f"  ⚠ Metric evaluation skipped: {me}")
+
+        try:
+            from erasus.experiments.experiment_tracker import ExperimentTracker
+
+            tracker = ExperimentTracker(
+                name=getattr(config, "experiment_name", "erasus_run"),
+                backend=getattr(config, "tracking_backend", "local"),
+                project=getattr(config, "tracking_project", "erasus"),
+            )
+            tracker.log_config(config.to_dict())
+            curves: dict[str, dict[str, list[float]]] = {
+                "forget_loss": {
+                    "x": [float(i) for i in range(len(result.forget_loss_history))],
+                    "y": [float(x) for x in result.forget_loss_history],
+                },
+            }
+            if result.retain_loss_history:
+                curves["retain_loss"] = {
+                    "x": [float(i) for i in range(len(result.retain_loss_history))],
+                    "y": [float(x) for x in result.retain_loss_history],
+                }
+            summary_metrics: dict = {}
+            if result.forget_loss_history:
+                summary_metrics["final_forget_loss"] = float(result.forget_loss_history[-1])
+            if result.retain_loss_history:
+                summary_metrics["final_retain_loss"] = float(result.retain_loss_history[-1])
+            summary_metrics.update({k: float(v) for k, v in eval_metrics.items() if isinstance(v, (int, float))})
+            tracker.log_unlearning_run(
+                strategy=config.strategy,
+                selector=config.selector,
+                metrics=summary_metrics,
+                curves=curves,
+                model_path=str(args.output) if args.output else None,
+                metadata={"elapsed_s": elapsed},
+            )
+            tracker.finish()
+        except Exception as te:
+            print(f"  ⚠ Experiment tracking skipped: {te}")
     else:
         print("  ⚠ No forget dataset specified or loadable.")
         print("  → Add 'forget_data_dir' to your YAML config or use --forget-dir.")

--- a/erasus/core/base_unlearner.py
+++ b/erasus/core/base_unlearner.py
@@ -87,6 +87,9 @@ class BaseUnlearner(ABC):
         early_stopping_mode: str = "max",
         precision: Optional[str] = None,
         gradient_checkpointing: bool = False,
+        resume_from: Optional[str] = None,
+        checkpoint_dir: Optional[str] = None,
+        checkpoint_every: int = 0,
         **kwargs: Any,
     ) -> UnlearningResult:
         """
@@ -116,6 +119,12 @@ class BaseUnlearner(ABC):
             Metric name to monitor. Default ``"forget_loss"``.
         early_stopping_mode : str
             ``"min"`` or ``"max"``. Default ``"max"`` (higher forget loss = better).
+        resume_from : str, optional
+            Directory or ``.pt`` path from ``save_unlearning_checkpoint`` to continue training.
+        checkpoint_dir : str, optional
+            Directory to write checkpoints when ``checkpoint_every`` > 0.
+        checkpoint_every : int
+            Save a checkpoint every N completed epochs (0 disables).
 
         Returns
         -------
@@ -124,6 +133,16 @@ class BaseUnlearner(ABC):
         """
         from erasus.core.coreset import Coreset
         from erasus.utils.early_stopping import EarlyStopping
+        from erasus.utils.unlearning_checkpoint import (
+            load_unlearning_checkpoint,
+            save_unlearning_checkpoint,
+        )
+
+        if resume_from and validate_every > 0 and validation_metrics:
+            raise ValueError(
+                "resume_from cannot be combined with in-loop validation "
+                "(validate_every + validation_metrics).",
+            )
 
         start = time.time()
 
@@ -170,6 +189,13 @@ class BaseUnlearner(ABC):
             coreset_size = len(forget_data.dataset)
             original_size = len(forget_data.dataset)
 
+        # Optional resume (loads weights + histories before training)
+        resume_meta: Dict[str, Any] = {}
+        if resume_from:
+            resume_meta = load_unlearning_checkpoint(
+                resume_from, self.model, map_location=self.device,
+            )
+
         # Setup early stopping
         stopper = None
         if early_stopping_patience > 0 and validate_every > 0:
@@ -183,6 +209,23 @@ class BaseUnlearner(ABC):
         best_epoch = 0
         stopped_early = False
         best_state = None
+
+        def _maybe_save_ckpt(
+            forget_losses: List[float],
+            retain_losses: List[float],
+            epochs_done: int,
+        ) -> None:
+            if not checkpoint_dir or checkpoint_every <= 0:
+                return
+            if epochs_done % checkpoint_every != 0:
+                return
+            save_unlearning_checkpoint(
+                checkpoint_dir,
+                model=self.model,
+                forget_losses=forget_losses,
+                retain_losses=retain_losses,
+                epochs_completed=epochs_done,
+            )
 
         if validate_every > 0 and validation_metrics:
             # Run epoch by epoch for in-loop validation
@@ -244,12 +287,30 @@ class BaseUnlearner(ABC):
                             stopped_early = True
                             break
 
+                _maybe_save_ckpt(all_forget_losses, all_retain_losses, epoch + 1)
+
             forget_losses = all_forget_losses
             retain_losses = all_retain_losses
 
             # Restore best model
             if best_state is not None:
                 self.model.load_state_dict(best_state)
+        elif resume_from or checkpoint_every > 0:
+            forget_losses = list(resume_meta.get("forget_losses", []))
+            retain_losses = list(resume_meta.get("retain_losses", []))
+            epochs_done = int(resume_meta.get("epochs_completed", 0))
+
+            for _ in range(epochs):
+                f_losses, r_losses = self._run_unlearning(
+                    forget_loader=forget_loader,
+                    retain_loader=retain_data,
+                    epochs=1,
+                    **kwargs,
+                )
+                forget_losses.extend(f_losses)
+                retain_losses.extend(r_losses)
+                epochs_done += 1
+                _maybe_save_ckpt(forget_losses, retain_losses, epochs_done)
         else:
             # Original path: run all epochs at once
             forget_losses, retain_losses = self._run_unlearning(

--- a/erasus/core/config.py
+++ b/erasus/core/config.py
@@ -5,7 +5,7 @@ Erasus Configuration Module.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import yaml
 
@@ -13,6 +13,8 @@ import yaml
 @dataclass
 class ErasusConfig:
     """Unified configuration for an Erasus unlearning run."""
+
+    experiment_name: str = "erasus_run"
 
     # Model
     model_name: str = "openai/clip-vit-base-patch32"
@@ -32,6 +34,11 @@ class ErasusConfig:
     epochs: int = 5
     batch_size: int = 32
     lr: float = 1e-4
+
+    # Evaluation / tracking
+    metrics: List[str] = field(default_factory=lambda: ["accuracy"])
+    tracking_backend: str = "local"
+    tracking_project: str = "erasus"
 
     # Logging
     log_dir: Optional[str] = None

--- a/erasus/experiments/hydra_config.py
+++ b/erasus/experiments/hydra_config.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import yaml
 
@@ -58,6 +58,8 @@ class SelectorConfig:
 class TrackingConfig:
     log_dir: Optional[str] = None
     wandb_project: Optional[str] = None
+    backend: str = "local"
+    project: str = "erasus"
 
 
 @dataclass
@@ -68,10 +70,13 @@ class ExperimentConfig:
     strategy: StrategyConfig = field(default_factory=StrategyConfig)
     selector: SelectorConfig = field(default_factory=SelectorConfig)
     tracking: TrackingConfig = field(default_factory=TrackingConfig)
+    metrics: List[str] = field(default_factory=lambda: ["accuracy"])
 
     def to_erasus_config(self) -> ErasusConfig:
         """Project a composed experiment config into the runtime config."""
+        proj = self.tracking.project or self.tracking.wandb_project or "erasus"
         return ErasusConfig(
+            experiment_name=self.experiment_name,
             model_name=self.model.name,
             model_type=self.model.model_type,
             device=self.model.device,
@@ -90,11 +95,72 @@ class ExperimentConfig:
             wandb_project=self.tracking.wandb_project,
             forget_data_dir=self.data.forget_data_dir,
             retain_data_dir=self.data.retain_data_dir,
+            metrics=list(self.metrics),
+            tracking_backend=self.tracking.backend,
+            tracking_project=proj,
         )
 
 
 class HydraConfigManager:
     """Compose experiment configs from YAML + dotted overrides."""
+
+    @staticmethod
+    def _normalize_flat_legacy(data: Dict[str, Any]) -> None:
+        """Merge flat keys (``model_name``, ``strategy``, …) into nested sections."""
+        # configs/default.yaml uses ``strategy: "name"`` which would overwrite the nested dict.
+        if isinstance(data.get("strategy"), str):
+            data["strategy"] = {
+                "name": data["strategy"],
+                "lr": data.get("lr", 1e-4),
+                "epochs": data.get("epochs", 5),
+                "extra_params": data.get("strategy_kwargs", {}) or {},
+            }
+        if isinstance(data.get("selector"), str):
+            data["selector"] = {
+                "name": data["selector"],
+                "prune_ratio": data.get("prune_ratio", 0.1),
+                "extra_params": data.get("selector_kwargs", {}) or {},
+            }
+
+        model = cast(Dict[str, Any], data.setdefault("model", {}))
+        if "model_name" in data:
+            model.setdefault("name", data["model_name"])
+        if "model_type" in data:
+            model.setdefault("model_type", data["model_type"])
+        if "device" in data:
+            model.setdefault("device", data["device"])
+
+        strat = cast(Dict[str, Any], data.setdefault("strategy", {}))
+        if "epochs" in data:
+            strat.setdefault("epochs", data["epochs"])
+        if "lr" in data:
+            strat.setdefault("lr", data["lr"])
+        sk = data.get("strategy_kwargs")
+        if isinstance(sk, dict):
+            ep = cast(Dict[str, Any], strat.setdefault("extra_params", {}))
+            ep.update(sk)
+
+        sel = cast(Dict[str, Any], data.setdefault("selector", {}))
+        if "prune_ratio" in data:
+            sel.setdefault("prune_ratio", data["prune_ratio"])
+        skw = data.get("selector_kwargs")
+        if isinstance(skw, dict):
+            ep2 = cast(Dict[str, Any], sel.setdefault("extra_params", {}))
+            ep2.update(skw)
+
+        ddata = cast(Dict[str, Any], data.setdefault("data", {}))
+        if "forget_data_dir" in data:
+            ddata.setdefault("forget_data_dir", data["forget_data_dir"])
+        if "retain_data_dir" in data:
+            ddata.setdefault("retain_data_dir", data["retain_data_dir"])
+        if "batch_size" in data:
+            ddata.setdefault("batch_size", data["batch_size"])
+
+        tr = cast(Dict[str, Any], data.setdefault("tracking", {}))
+        if "log_dir" in data:
+            tr.setdefault("log_dir", data["log_dir"])
+        if "wandb_project" in data:
+            tr.setdefault("wandb_project", data["wandb_project"])
 
     @staticmethod
     def _apply_override(data: Dict[str, Any], override: str) -> None:
@@ -126,6 +192,7 @@ class HydraConfigManager:
             if not isinstance(loaded, dict):
                 raise ValueError("Experiment config must deserialize to a mapping.")
             data.update(loaded)
+            cls._normalize_flat_legacy(data)
 
         for override in overrides or []:
             cls._apply_override(data, override)
@@ -147,6 +214,7 @@ class HydraConfigManager:
             strategy=StrategyConfig(**data.get("strategy", {})),
             selector=SelectorConfig(**data.get("selector", {})),
             tracking=TrackingConfig(**data.get("tracking", {})),
+            metrics=list(data.get("metrics", ["accuracy"])),
         )
 
 

--- a/erasus/metrics/metric_suite.py
+++ b/erasus/metrics/metric_suite.py
@@ -56,6 +56,11 @@ class MetricSuite:
     def metric_names(self) -> List[str]:
         return [type(m).__name__ for m in self._instances]
 
+    @property
+    def metrics(self) -> List[Any]:
+        """Instantiated metric objects used by :meth:`run`."""
+        return self._instances
+
     def add(self, metric: Union[str, Any]) -> "MetricSuite":
         """Add a metric to the suite (fluent API)."""
         if isinstance(metric, str):

--- a/erasus/service/api.py
+++ b/erasus/service/api.py
@@ -1,9 +1,16 @@
 """
-FastAPI service scaffold for unlearning-as-a-service.
+FastAPI service for unlearning-as-a-service.
+
+Endpoints cover health, strategy discovery, planning, lightweight job tracking,
+and a synthetic ``/unlearn/simulate`` demo that runs a tiny on-server unlearning
+step (for integration tests and smoke checks).
 """
 
 from __future__ import annotations
 
+import threading
+import time
+import uuid
 from typing import Any
 
 from erasus.core.registry import strategy_registry
@@ -26,16 +33,72 @@ def plan_unlearning_request(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def run_synthetic_unlearning(strategy_name: str = "gradient_ascent", epochs: int = 1) -> dict[str, Any]:
+    """Execute a tiny CPU unlearning pass for demos and tests."""
+    import torch
+    import torch.nn as nn
+    from torch.utils.data import DataLoader, TensorDataset
+
+    from erasus.core.registry import strategy_registry
+
+    in_dim, n_classes = 16, 4
+    n_forget, n_retain = 32, 64
+    model = nn.Sequential(
+        nn.Linear(in_dim, 16),
+        nn.ReLU(),
+        nn.Linear(16, n_classes),
+    )
+    forget_loader = DataLoader(
+        TensorDataset(
+            torch.randn(n_forget, in_dim),
+            torch.randint(0, n_classes, (n_forget,)),
+        ),
+        batch_size=8,
+    )
+    retain_loader = DataLoader(
+        TensorDataset(
+            torch.randn(n_retain, in_dim),
+            torch.randint(0, n_classes, (n_retain,)),
+        ),
+        batch_size=8,
+    )
+    strategy_cls = strategy_registry.get(strategy_name)
+    strategy = strategy_cls(lr=1e-3)
+    t0 = time.perf_counter()
+    model, fl, rl = strategy.unlearn(model, forget_loader, retain_loader, epochs=epochs)
+    elapsed = time.perf_counter() - t0
+    return {
+        "strategy": strategy_name,
+        "epochs": epochs,
+        "time_s": round(elapsed, 4),
+        "final_forget_loss": float(fl[-1]) if fl else None,
+        "final_retain_loss": float(rl[-1]) if rl else None,
+        "param_count": sum(p.numel() for p in model.parameters()),
+    }
+
+
+_JOBS_LOCK = threading.Lock()
+_JOBS: dict[str, dict[str, Any]] = {}
+
+
 def create_app() -> Any:
-    from fastapi import FastAPI
-    from pydantic import BaseModel
+    from fastapi import BackgroundTasks, FastAPI
+    from pydantic import BaseModel, Field
 
     class UnlearningRequest(BaseModel):
         strategy: str = "gradient_ascent"
         selector: str | None = None
-        epochs: int = 1
+        epochs: int = Field(1, ge=1, le=32)
 
-    app = FastAPI(title="Erasus API", version="0.1.1")
+    class JobCreateResponse(BaseModel):
+        job_id: str
+        status: str
+
+    app = FastAPI(
+        title="Erasus API",
+        version="0.1.1",
+        description="Machine unlearning orchestration — plan, track, and simulate runs.",
+    )
 
     @app.get("/health")
     def health() -> dict[str, str]:
@@ -48,5 +111,49 @@ def create_app() -> Any:
     @app.post("/unlearn/plan")
     def plan(request: UnlearningRequest) -> dict[str, Any]:
         return plan_unlearning_request(request.model_dump())
+
+    @app.post("/unlearn/simulate")
+    def simulate(request: UnlearningRequest) -> dict[str, Any]:
+        """Run a tiny synthetic unlearning job synchronously (smoke / demo)."""
+        return run_synthetic_unlearning(request.strategy, epochs=request.epochs)
+
+    def _run_job(job_id: str, strategy: str, epochs: int) -> None:
+        with _JOBS_LOCK:
+            _JOBS[job_id]["status"] = "running"
+        try:
+            result = run_synthetic_unlearning(strategy, epochs=epochs)
+            with _JOBS_LOCK:
+                _JOBS[job_id]["status"] = "completed"
+                _JOBS[job_id]["result"] = result
+        except Exception as exc:
+            with _JOBS_LOCK:
+                _JOBS[job_id]["status"] = "failed"
+                _JOBS[job_id]["error"] = str(exc)
+
+    @app.post("/unlearn/jobs", response_model=JobCreateResponse)
+    def submit_job(
+        request: UnlearningRequest,
+        background_tasks: BackgroundTasks,
+    ) -> JobCreateResponse:
+        """Queue a synthetic unlearning job (background thread)."""
+        job_id = str(uuid.uuid4())
+        with _JOBS_LOCK:
+            _JOBS[job_id] = {
+                "status": "queued",
+                "strategy": request.strategy,
+                "epochs": request.epochs,
+            }
+        background_tasks.add_task(_run_job, job_id, request.strategy, request.epochs)
+        return JobCreateResponse(job_id=job_id, status="queued")
+
+    @app.get("/unlearn/jobs/{job_id}")
+    def job_status(job_id: str) -> dict[str, Any]:
+        with _JOBS_LOCK:
+            job = _JOBS.get(job_id)
+        if job is None:
+            from fastapi import HTTPException
+
+            raise HTTPException(status_code=404, detail="Unknown job_id")
+        return {"job_id": job_id, **job}
 
     return app

--- a/erasus/utils/unlearning_checkpoint.py
+++ b/erasus/utils/unlearning_checkpoint.py
@@ -1,0 +1,83 @@
+"""
+Checkpoint save/load for resumable unlearning runs.
+
+Serialises model weights plus loss histories and epoch counters so
+``BaseUnlearner.fit(resume_from=...)`` can continue training.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.nn as nn
+
+
+def _paths(base: Path) -> tuple[Path, Path]:
+    return base / "unlearning_checkpoint.pt", base / "unlearning_checkpoint.json"
+
+
+def save_unlearning_checkpoint(
+    path: str | Path,
+    *,
+    model: nn.Module,
+    forget_losses: List[float],
+    retain_losses: List[float],
+    epochs_completed: int,
+    extra: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Save model state and metadata for resume."""
+    base = Path(path)
+    if base.suffix in (".pt", ".pth"):
+        base = base.parent
+    base.mkdir(parents=True, exist_ok=True)
+    pt_path, json_path = _paths(base)
+    torch.save(model.state_dict(), pt_path)
+    payload = {
+        "epochs_completed": epochs_completed,
+        "forget_losses": forget_losses,
+        "retain_losses": retain_losses,
+        **(extra or {}),
+    }
+    json_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def load_unlearning_checkpoint(
+    path: str | Path,
+    model: nn.Module,
+    map_location: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Load weights into ``model`` and return metadata (loss histories, epochs_completed).
+
+    Parameters
+    ----------
+    path
+        Directory containing ``unlearning_checkpoint.pt`` and ``.json``, or a ``.pt`` file
+        (metadata JSON must sit beside it with the same stem).
+    """
+    p = Path(path)
+    if p.is_file() and p.suffix in (".pt", ".pth"):
+        pt_path = p
+        json_path = p.with_suffix(".json")
+        base = p.parent
+    else:
+        base = p
+        pt_path, json_path = _paths(base)
+
+    if not pt_path.exists():
+        raise FileNotFoundError(f"Checkpoint not found: {pt_path}")
+
+    state = torch.load(pt_path, map_location=map_location or "cpu")
+    model.load_state_dict(state)
+
+    meta: Dict[str, Any] = {
+        "epochs_completed": 0,
+        "forget_losses": [],
+        "retain_losses": [],
+    }
+    if json_path.exists():
+        meta.update(json.loads(json_path.read_text(encoding="utf-8")))
+    return meta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ dev = [
     "ruff>=0.1",
     "mypy>=1.5",
     "pre-commit>=3.4",
+    "fastapi>=0.110",
+    "httpx>=0.27",
 ]
 
 [project.scripts]

--- a/tests/real_models/test_tiny_hf_models.py
+++ b/tests/real_models/test_tiny_hf_models.py
@@ -1,5 +1,8 @@
 """
 Slow tests for tiny real-model integrations.
+
+Uses synthetic HuggingFace configs (no weight downloads). Also marked
+``real_models`` so CI can group optional HF-heavy jobs.
 """
 
 from __future__ import annotations
@@ -8,7 +11,7 @@ import pytest
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 
-pytestmark = pytest.mark.slow
+pytestmark = [pytest.mark.slow, pytest.mark.real_models]
 
 
 def _make_token_loader(vocab_size: int = 64) -> DataLoader:

--- a/tests/unit/test_hydra_config.py
+++ b/tests/unit/test_hydra_config.py
@@ -42,3 +42,24 @@ def test_compose_from_yaml(tmp_path: Path):
     assert config.model.name == "gpt2"
     assert config.strategy.name == "altpo"
     assert config.strategy.epochs == 3
+
+
+def test_compose_flat_legacy_mimics_default_yaml(tmp_path: Path):
+    """Flat ``strategy: name`` style merges into nested StrategyConfig."""
+    p = tmp_path / "flat.yaml"
+    p.write_text(
+        'model_name: "openai/clip-vit-base-patch32"\n'
+        'model_type: "vlm"\n'
+        'strategy: "gradient_ascent"\n'
+        'selector: "random"\n'
+        "epochs: 7\n"
+        "lr: 0.001\n"
+    )
+    cfg = compose_experiment_config(str(p))
+    assert cfg.model.name == "openai/clip-vit-base-patch32"
+    assert cfg.strategy.name == "gradient_ascent"
+    assert cfg.strategy.epochs == 7
+    assert cfg.strategy.lr == 0.001
+    ec = cfg.to_erasus_config()
+    assert ec.epochs == 7
+    assert "accuracy" in ec.metrics

--- a/tests/unit/test_service_api.py
+++ b/tests/unit/test_service_api.py
@@ -4,7 +4,14 @@ Tests for the FastAPI service helpers.
 
 from __future__ import annotations
 
-from erasus.service.api import list_registered_strategies, plan_unlearning_request
+import pytest
+
+from erasus.service.api import (
+    create_app,
+    list_registered_strategies,
+    plan_unlearning_request,
+    run_synthetic_unlearning,
+)
 
 
 def test_list_registered_strategies():
@@ -16,3 +23,39 @@ def test_plan_unlearning_request():
     plan = plan_unlearning_request({"strategy": "npo", "selector": "random"})
     assert plan["status"] == "accepted"
     assert plan["strategy"] == "npo"
+
+
+def test_run_synthetic_unlearning():
+    out = run_synthetic_unlearning("gradient_ascent", epochs=1)
+    assert out["time_s"] >= 0
+    assert "final_forget_loss" in out
+
+
+@pytest.mark.parametrize("endpoint", ["/health", "/strategies", "/unlearn/plan"])
+def test_fastapi_endpoints(endpoint):
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    client = TestClient(create_app())
+    if endpoint == "/unlearn/plan":
+        r = client.post(endpoint, json={"strategy": "gradient_ascent", "epochs": 1})
+    else:
+        r = client.get(endpoint)
+    assert r.status_code == 200
+
+
+def test_unlearn_simulate_and_jobs():
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    client = TestClient(create_app())
+    r = client.post("/unlearn/simulate", json={"strategy": "gradient_ascent", "epochs": 1})
+    assert r.status_code == 200
+    assert r.json()["strategy"] == "gradient_ascent"
+
+    jr = client.post("/unlearn/jobs", json={"strategy": "gradient_ascent", "epochs": 1})
+    assert jr.status_code == 200
+    job_id = jr.json()["job_id"]
+    st = client.get(f"/unlearn/jobs/{job_id}")
+    assert st.status_code == 200
+    assert st.json()["job_id"] == job_id

--- a/tests/unit/test_standard_suite.py
+++ b/tests/unit/test_standard_suite.py
@@ -15,6 +15,7 @@ def test_standard_benchmark_suite_runs(tmp_path):
     report = suite.run()
 
     assert len(report.entries) == 4
+    assert all(e.status == "ok" for e in report.entries)
 
     json_path = tmp_path / "suite.json"
     md_path = tmp_path / "suite.md"

--- a/tests/unit/test_unlearning_checkpoint.py
+++ b/tests/unit/test_unlearning_checkpoint.py
@@ -1,0 +1,61 @@
+"""Tests for resumable unlearning checkpoints."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from erasus.utils.unlearning_checkpoint import (
+    load_unlearning_checkpoint,
+    save_unlearning_checkpoint,
+)
+
+
+def test_save_and_load_roundtrip():
+    model = nn.Linear(8, 2)
+    with tempfile.TemporaryDirectory() as tmp:
+        save_unlearning_checkpoint(
+            tmp,
+            model=model,
+            forget_losses=[1.0, 0.5],
+            retain_losses=[2.0],
+            epochs_completed=2,
+        )
+        m2 = nn.Linear(8, 2)
+        meta = load_unlearning_checkpoint(tmp, m2)
+        assert meta["epochs_completed"] == 2
+        assert meta["forget_losses"] == [1.0, 0.5]
+        assert torch.allclose(model.weight, m2.weight)
+
+
+def test_base_unlearner_resume(tmp_path: Path):
+    from erasus.unlearners.erasus_unlearner import ErasusUnlearner
+
+    n, d, c = 24, 8, 3
+    forget = DataLoader(
+        TensorDataset(torch.randn(n, d), torch.randint(0, c, (n,))),
+        batch_size=8,
+    )
+    retain = DataLoader(
+        TensorDataset(torch.randn(n, d), torch.randint(0, c, (n,))),
+        batch_size=8,
+    )
+    model = nn.Sequential(nn.Linear(d, 4), nn.ReLU(), nn.Linear(4, c))
+    ck_dir = tmp_path / "ck"
+    u = ErasusUnlearner(model=model, strategy="gradient_ascent", device="cpu")
+    u.fit(
+        forget,
+        retain,
+        epochs=1,
+        checkpoint_dir=str(ck_dir),
+        checkpoint_every=1,
+    )
+    assert (ck_dir / "unlearning_checkpoint.pt").exists()
+
+    u2 = ErasusUnlearner(model=model, strategy="gradient_ascent", device="cpu")
+    u2.fit(forget, retain, epochs=1, resume_from=str(ck_dir))


### PR DESCRIPTION
## Summary

Implements the requested roadmap items: documented stable/experimental root exports, unified benchmark suite runs, expanded FastAPI service, experiment tracking in the unlearn CLI, full nested YAML example + flat config merge, resumable unlearning checkpoints, profiling CLI, and pre-commit pytest smoke.

## Closes

Closes #69
Closes #71
Closes #73
Closes #76
Closes #79
Closes #82
Closes #83
Closes #84
Closes #85

## Key changes

- **#69** — Module docstring for `STABLE_EXPORTS` / `PUBLIC_API_STATUS` on the package root.
- **#71** — `tests/real_models/test_tiny_hf_models.py` also marked `@pytest.mark.real_models` (with `slow`).
- **#73** — FastAPI: `/unlearn/simulate`, `POST /unlearn/jobs`, `GET /unlearn/jobs/{id}`; synthetic `run_synthetic_unlearning` helper.
- **#76** — `StandardBenchmarkSuite.run()` executes `micro_protocol` per benchmark and writes JSON + Markdown reports.
- **#79** — `erasus unlearn` logs runs via `ExperimentTracker` (config `tracking.backend` / CLI `--tracking-backend`).
- **#82** — `configs/example_full_run.yaml`; Hydra `_normalize_flat_legacy` fixes flat `configs/default.yaml` style (string `strategy:` / `selector:`).
- **#83** — `erasus.utils.unlearning_checkpoint`; `BaseUnlearner.fit(resume_from=..., checkpoint_dir=..., checkpoint_every=...)`.
- **#84** — `erasus profile` and `--profile` on `unlearn`.
- **#85** — Pre-commit: pytest public API smoke (existing ruff/mypy hooks retained).

## Dev dependencies

- `fastapi` and `httpx` added to `[project.optional-dependencies] dev` so FastAPI route tests can run in CI when `pip install -e '.[dev]'`.

Made with [Cursor](https://cursor.com)